### PR TITLE
Create Web Port with Emscripten

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -62,30 +62,45 @@ jobs:
       - name: Install CMake
         uses: lukka/get-cmake@latest
 
-      - name: Setup MSVC
-        if: matrix.platform == 'Windows'
+      - if: matrix.platform == 'Windows'
+        name: Windows setup
         uses: microsoft/setup-msbuild@v2
 
-      - name: Setup Linux
-        if: matrix.platform == 'Linux'
+      - if: matrix.platform == 'Linux'
+        name: Linux setup
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
             libgtk-3-dev \
             pkg-config
-          cmake -B build -DCMAKE_BUILD_TYPE=Release
 
-      - name: Configure CMake (Windows)
-        if: matrix.platform == 'Windows'
-        run: cmake -B build -G "Visual Studio 17 2022" -A x64
+      - name: Configure CMake
+        shell: bash
+        run: |
+          if [ "${{ matrix.platform }}" == "Windows" ]; then
+            cmake \
+              -B build \
+              -G "Visual Studio 17 2022" \
+              -A x64
+          elif [ "${{ matrix.platform }}" == "Linux" ]; then
+            cmake \
+              -B build \
+              -DCMAKE_BUILD_TYPE=Release
+          fi
 
       - name: Build everything
-        run: cmake --build build --config Release --parallel
+        run: |
+          cmake \
+            --build build \
+            --config Release \
+            --parallel
 
       - name: Create binary packages
         working-directory: build
-        run: cpack -C Release
+        run: |
+          cpack \
+            -C Release
 
       - name: Upload packages
         uses: actions/upload-artifact@v7
@@ -120,7 +135,9 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
+          git tag \
+            --annotate "v${{ inputs.version }}" \
+            --message "Release v${{ inputs.version }}"
           git push origin "v${{ inputs.version }}"
 
       - name: Create GitHub Release

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -1,0 +1,53 @@
+name: Deploy Web Build
+run-name: >-
+  Deploy Web: ${{
+    github.event_name == 'push' && github.event.head_commit.message ||
+    format('Triggered by {0}', github.actor)
+  }}
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            ninja-build
+
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: latest
+
+      - name: Configure Emscripten CMake
+        run: |
+          emcmake cmake \
+            -S . \
+            -B build-web \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DSDL_PTHREADS=ON
+
+      - name: Build Web Target
+        run: |
+          cmake \
+            --build build-web \
+            --target emulator-web \
+            --parallel
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy build-web/bin --project-name=game-boy-emulator

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -7,6 +7,7 @@ run-name: >-
 
 on:
   push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy build-web/bin --project-name=game-boy-emulator --branch main
+          command: pages deploy build-web/bin --project-name=game-boy-emulator

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy build-web/bin --project-name=game-boy-emulator
+          command: pages deploy build-web/bin --project-name=game-boy-emulator --branch main

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -7,7 +7,6 @@ run-name: >-
 
 on:
   push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,9 +8,9 @@ run-name: >-
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
   workflow_call:
 
@@ -32,13 +32,23 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . -B build \
+          cmake \
+            -S . \
+            -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DSDL_UNIX_CONSOLE_BUILD=ON \
             -DCMAKE_CXX_FLAGS="-Wno-stringop-overflow"
 
       - name: Build Test Harnesses and Emulator
-        run: cmake --build build --parallel --target game-boy-tests
+        run: |
+          cmake \
+            --build build \
+            --parallel \
+            --target game-boy-tests
 
       - name: Run Tests
-        run: ctest --test-dir build --parallel $(nproc) --output-on-failure
+        run: |
+          ctest \
+            --test-dir build \
+            --parallel $(nproc) \
+            --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-build/
+build*/

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ A cross-platform, cycle-accurate Nintendo Game Boy emulator written in C++. Game
 | ------------- | ----------------- |
 | Load Game ROM | <kbd>O     </kbd> |
 | Fast-Forward  | <kbd>Space </kbd> |
-| Pause         | <kbd>Escape</kbd> |
+| Pause         | <kbd>P     </kbd> |
 | Reset         | <kbd>R     </kbd> |
-| Fullscreen    | <kbd>F11   </kbd> |
+| Fullscreen    | <kbd>F     </kbd> |
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ A cross-platform, cycle-accurate Nintendo Game Boy emulator written in C++. Game
 |----------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | ![Pokémon Yellow: Special Pikachu Edition - Gameplay](https://github.com/user-attachments/assets/a6dce68c-cbb2-4688-8d13-b7fac0789bbb) | ![Donkey Kong Land - Gameplay](https://github.com/user-attachments/assets/634cb879-4189-4196-b395-6e6e06999298)   | ![The Legend of Zelda: Link's Awakening - Gameplay](https://github.com/user-attachments/assets/fc67733c-b722-44d2-9a22-70717476da85) |
 
-## Usage Instructions
+## Setup
+### Web
+1. Visit https://game-boy-emulator.pages.dev/ to access the latest emulator version from the `main` branch.
+
+### Desktop
 1. Download the latest available version for your operating system from the `Releases` tab.
 2. Unzip the folder and run `emulator-gui.exe`.
-3. Acquire a Game Boy game ROM file (not provided but found online easily).
-4. In the top menu click `File`->`Load Game ROM`.
-5. Select the ROM file to run from the file selector.
-6. If the game is currently supported, it will now be running and will be interactable via the default key mappings below.
+
+## Usage
+1. Acquire a Game Boy game ROM file (not provided but found online easily).
+2. In the top menu click `File`->`Load Game ROM`.
+3. Select the ROM file to run from the file selector.
+4. If the game is currently supported, it will now be running and will be interactable via the default key mappings below.
 
 ## Default Controls
 <table>
@@ -55,8 +61,7 @@ A cross-platform, cycle-accurate Nintendo Game Boy emulator written in C++. Game
 
 ## Future Additions
 - Implement the Audio Processing Unit to recreate sound from Game Boy ROMs.
-- Implement save state exporting and cartridge ram exporting.
-- Port to browser with Emscripten.
+- Implement save states for storing progress between sessions.
 - Add support for Game Boy Color games. 
 
 ## Compilation

--- a/cmake/FindImGui.cmake
+++ b/cmake/FindImGui.cmake
@@ -24,6 +24,6 @@ target_link_libraries(ImGui PUBLIC
     SDL3::SDL3)
 
 install(FILES "${imgui_SOURCE_DIR}/LICENSE.txt"
-        DESTINATION third-party-licenses
-        RENAME imgui_license.txt
-        COMPONENT documentation)
+    DESTINATION third-party-licenses
+    RENAME imgui_license.txt
+    COMPONENT documentation)

--- a/cmake/FindNativeFileDialogExtended.cmake
+++ b/cmake/FindNativeFileDialogExtended.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     NativeFileDialogExtended
     GIT_REPOSITORY https://github.com/btzy/nativefiledialog-extended.git
-    GIT_TAG e092bbb4578583c6fd0edc2cd14fb9c658194a4d
+    GIT_TAG 3cd252a8f7ca32419b1ca235c2990ba6a0ecba7c
     GIT_SHALLOW TRUE)
 
 FetchContent_MakeAvailable(NativeFileDialogExtended)

--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -11,5 +11,6 @@ target_include_directories(game-boy-emulator PUBLIC
     "include")
 
 if(EMSCRIPTEN)
-    target_compile_options(game-boy-emulator PRIVATE -pthread)
+    target_compile_options(game-boy-emulator PRIVATE
+        -pthread)
 endif()

--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -9,3 +9,7 @@ add_library(game-boy-emulator
 
 target_include_directories(game-boy-emulator PUBLIC
     "include")
+
+if(EMSCRIPTEN)
+    target_compile_options(game-boy-emulator PRIVATE -pthread)
+endif()

--- a/emulator/include/emulator.h
+++ b/emulator/include/emulator.h
@@ -46,6 +46,7 @@ public:
     void update_dpad_direction_pressed_state_thread_safe(uint8_t direction_flag_mask, bool is_direction_pressed);
 
     uint8_t get_published_frame_buffer_index_thread_safe() const;
+    uint64_t get_published_frame_sequence_number_thread_safe() const;
     std::unique_ptr<uint8_t[]>& get_pixel_frame_buffer(uint8_t index);
 
     std::string get_loaded_game_rom_title_thread_safe() const;

--- a/emulator/include/pixel_processing_unit.h
+++ b/emulator/include/pixel_processing_unit.h
@@ -195,6 +195,7 @@ public:
     void set_post_boot_state();
 
     uint8_t get_published_frame_buffer_index_thread_safe() const;
+    uint64_t get_published_frame_sequence_number_thread_safe() const;
     std::unique_ptr<uint8_t[]>& get_pixel_frame_buffer(uint8_t index);
 
     uint8_t read_lcdc_lcd_control() const;
@@ -217,6 +218,7 @@ private:
     std::function<void(uint8_t)> request_interrupt_callback;
 
     std::atomic<uint8_t> published_frame_index_atomic{};
+    std::atomic<uint64_t> published_frame_sequence_number_atomic{};
     uint8_t in_progress_frame_index{1};
     std::unique_ptr<uint8_t[]> pixel_frame_buffers[2];
 

--- a/emulator/src/emulator.cpp
+++ b/emulator/src/emulator.cpp
@@ -136,6 +136,11 @@ uint8_t Emulator::get_published_frame_buffer_index_thread_safe() const
     return pixel_processing_unit.get_published_frame_buffer_index_thread_safe();
 }
 
+uint64_t Emulator::get_published_frame_sequence_number_thread_safe() const
+{
+    return pixel_processing_unit.get_published_frame_sequence_number_thread_safe();
+}
+
 std::unique_ptr<uint8_t[]>& Emulator::get_pixel_frame_buffer(uint8_t index)
 {
     return pixel_processing_unit.get_pixel_frame_buffer(index);

--- a/emulator/src/pixel_processing_unit.cpp
+++ b/emulator/src/pixel_processing_unit.cpp
@@ -111,6 +111,11 @@ uint8_t PixelProcessingUnit::get_published_frame_buffer_index_thread_safe() cons
     return published_frame_index_atomic.load(std::memory_order_acquire);
 }
 
+uint64_t PixelProcessingUnit::get_published_frame_sequence_number_thread_safe() const
+{
+    return published_frame_sequence_number_atomic.load(std::memory_order_acquire);
+}
+
 std::unique_ptr<uint8_t[]>& PixelProcessingUnit::get_pixel_frame_buffer(uint8_t index)
 {
     return pixel_frame_buffers[index];
@@ -777,6 +782,7 @@ uint8_t PixelProcessingUnit::get_object_fetcher_tile_row_byte(uint8_t offset)
 void PixelProcessingUnit::publish_new_frame()
 {
     published_frame_index_atomic.store(in_progress_frame_index, std::memory_order_release);
+    published_frame_sequence_number_atomic.fetch_add(1, std::memory_order_release);
     in_progress_frame_index = 1 - in_progress_frame_index;
 }
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,41 +1,90 @@
 find_package(Carlito REQUIRED)
 find_package(ImGui REQUIRED)
-find_package(NativeFileDialogExtended REQUIRED)
 find_package(SDL3 REQUIRED)
 
-add_executable(emulator-gui
-    "src/display_utilities.cpp"
-    "src/imgui_rendering.cpp"
-    "src/input_events.cpp"
-    "src/main.cpp"
-    "src/persistent_settings.cpp")
+if(EMSCRIPTEN)
+    ###############################################################################
+    # Web Builds
+    ###############################################################################
+    add_executable(emulator-web
+        "src/display_utilities.cpp"
+        "src/imgui_rendering.cpp"
+        "src/input_events.cpp"
+        "src/main.cpp"
+        "src/persistent_settings.cpp")
 
-target_include_directories(emulator-gui PRIVATE
-    "include"
-    ${CARLITO_INCLUDE_DIR})
+    target_include_directories(emulator-web PRIVATE
+        "include"
+        ${CARLITO_INCLUDE_DIR})
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message(STATUS "Building emulator-gui on Linux.")
+    target_link_libraries(emulator-web PRIVATE
+        game-boy-emulator
+        ImGui
+        SDL3::SDL3)
 
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
+    target_compile_options(emulator-web PRIVATE
+        -pthread)
+
+    target_link_options(emulator-web PRIVATE
+        -pthread
+        -sPTHREAD_POOL_SIZE=2
+        -sALLOW_MEMORY_GROWTH=1
+        -sMAXIMUM_MEMORY=268435456
+        -sFORCE_FILESYSTEM=1
+        --shell-file "${CMAKE_CURRENT_SOURCE_DIR}/web/shell.html")
+
+    set_target_properties(emulator-web PROPERTIES
+        OUTPUT_NAME "index"
+        SUFFIX ".html")
+
+    # This generated file is for Cloudflare Pages to read and attach the specified HTTP headers to every response
+    # These headers are required for Emscripten pthread support
+    file(GENERATE
+        OUTPUT "${CMAKE_BINARY_DIR}/bin/_headers"
+        CONTENT [[
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+]])
+
+else()
+    ###############################################################################
+    # Desktop Builds
+    ###############################################################################
+    find_package(NativeFileDialogExtended REQUIRED)
+
+    add_executable(emulator-gui
+        "src/display_utilities.cpp"
+        "src/imgui_rendering.cpp"
+        "src/input_events.cpp"
+        "src/main.cpp"
+        "src/persistent_settings.cpp")
 
     target_include_directories(emulator-gui PRIVATE
-        ${GTK3_INCLUDE_DIRS})
+        "include"
+        ${CARLITO_INCLUDE_DIR})
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
+
+        target_include_directories(emulator-gui PRIVATE
+            ${GTK3_INCLUDE_DIRS})
+
+        target_link_libraries(emulator-gui PRIVATE
+            ${GTK3_LIBRARIES})
+
+        target_compile_options(emulator-gui PRIVATE
+            ${GTK3_CFLAGS_OTHER})
+    endif()
 
     target_link_libraries(emulator-gui PRIVATE
-        ${GTK3_LIBRARIES})
+        game-boy-emulator
+        ImGui
+        nfd
+        SDL3::SDL3)
 
-    target_compile_options(emulator-gui PRIVATE
-        ${GTK3_CFLAGS_OTHER})
-endif()
-
-target_link_libraries(emulator-gui PRIVATE
-    game-boy-emulator
-    ImGui
-    nfd
-    SDL3::SDL3)
-
-install(TARGETS emulator-gui RUNTIME
+    install(TARGETS emulator-gui RUNTIME
         DESTINATION .
         COMPONENT gui)
+endif()

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -27,9 +27,8 @@ if(EMSCRIPTEN)
 
     target_link_options(emulator-web PRIVATE
         -pthread
-        -sPTHREAD_POOL_SIZE=2
-        -sALLOW_MEMORY_GROWTH=1
-        -sMAXIMUM_MEMORY=268435456
+        -sPTHREAD_POOL_SIZE=1
+        -sINITIAL_MEMORY=67108864
         -sFORCE_FILESYSTEM=1
         --shell-file "${CMAKE_CURRENT_SOURCE_DIR}/web/shell.html")
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -11,7 +11,8 @@ if(EMSCRIPTEN)
         "src/imgui_rendering.cpp"
         "src/input_events.cpp"
         "src/main.cpp"
-        "src/persistent_settings.cpp")
+        "src/persistent_settings.cpp"
+        "src/web_main_loop.cpp")
 
     target_include_directories(emulator-web PRIVATE
         "include"
@@ -57,7 +58,8 @@ else()
         "src/imgui_rendering.cpp"
         "src/input_events.cpp"
         "src/main.cpp"
-        "src/persistent_settings.cpp")
+        "src/persistent_settings.cpp"
+        "src/web_main_loop.cpp")
 
     target_include_directories(emulator-gui PRIVATE
         "include"

--- a/gui/include/display_utilities.h
+++ b/gui/include/display_utilities.h
@@ -67,7 +67,7 @@ void update_colour_palette(
     const uint8_t currently_published_frame_buffer_index);
 
 bool should_main_menu_bar_and_cursor_be_visible(
-    GameBoyEmulator::Emulator& game_boy_emulator,
+    const GameBoyEmulator::Emulator& game_boy_emulator,
     const EmulationController& emulation_controller,
     MenuAndCursorDisplayStatus& fullscreen_display_status,
     bool is_custom_palette_editor_open,

--- a/gui/include/display_utilities.h
+++ b/gui/include/display_utilities.h
@@ -89,8 +89,6 @@ struct web_viewport_metrics_t
 double get_web_device_pixel_ratio();
 
 web_viewport_metrics_t get_web_viewport_metrics();
-
-void log_web_display_metrics(SDL_Window* sdl_window, const char* reason);
 #endif
 
 void render_frame(RenderContext& context);

--- a/gui/include/display_utilities.h
+++ b/gui/include/display_utilities.h
@@ -76,6 +76,23 @@ bool should_main_menu_bar_and_cursor_be_visible(
 
 void update_imgui_scale_by_resolution(SDL_Window* sdl_window);
 
+#ifdef __EMSCRIPTEN__
+struct web_viewport_metrics_t
+{
+    int css_viewport_width{};
+    int css_viewport_height{};
+    int pixel_viewport_width{};
+    int pixel_viewport_height{};
+    double device_pixel_ratio{1.0};
+};
+
+double get_web_device_pixel_ratio();
+
+web_viewport_metrics_t get_web_viewport_metrics();
+
+void log_web_display_metrics(SDL_Window* sdl_window, const char* reason);
+#endif
+
 void render_frame(RenderContext& context);
 
 // Used in workaround for https://github.com/ocornut/imgui/issues/8339

--- a/gui/include/display_utilities.h
+++ b/gui/include/display_utilities.h
@@ -76,7 +76,7 @@ bool should_main_menu_bar_and_cursor_be_visible(
 
 void update_imgui_scale_by_resolution(SDL_Window* sdl_window);
 
-void render_frame(RenderContext& context, bool should_skip_frame_data_update);
+void render_frame(RenderContext& context);
 
 // Used in workaround for https://github.com/ocornut/imgui/issues/8339
 struct sdl_logical_presentation_imgui_workaround_t

--- a/gui/include/display_utilities.h
+++ b/gui/include/display_utilities.h
@@ -71,8 +71,7 @@ bool should_main_menu_bar_and_cursor_be_visible(
     const EmulationController& emulation_controller,
     MenuAndCursorDisplayStatus& fullscreen_display_status,
     bool is_custom_palette_editor_open,
-    bool is_keybinds_editor_open,
-    SDL_Window* sdl_window);
+    bool is_keybinds_editor_open);
 
 void update_imgui_scale_by_resolution(SDL_Window* sdl_window);
 

--- a/gui/include/gui_state_types.h
+++ b/gui/include/gui_state_types.h
@@ -122,12 +122,32 @@ struct MenuProperties
     KeybindsEditorState keybinds_editor_state{};
 };
 
+struct FrameDiagnosticsState
+{
+    static constexpr double SAMPLE_WINDOW_SECONDS = 1.0;
+
+    bool is_overlay_enabled = false;
+    bool has_completed_sample = false;
+    uint64_t performance_counter_frequency{};
+    uint64_t previous_frame_counter{};
+    uint64_t previous_published_frame_sequence_number{};
+    double displayed_worst_frame_time_ms{};
+    double displayed_emulator_frame_rate{};
+    uint32_t displayed_skipped_frame_count{};
+    double sample_elapsed_seconds{};
+    double sample_worst_frame_time_ms{};
+    uint32_t sample_frame_count{};
+    uint32_t sample_emulator_frame_count{};
+    uint32_t sample_skipped_frame_count{};
+};
+
 struct RenderContext
 {
     GameBoyEmulator::Emulator* game_boy_emulator{};
     EmulationController* emulation_controller{};
     FileLoadingStatus* file_loading_status{};
     MenuAndCursorDisplayStatus* menu_and_cursor_display_status{};
+    FrameDiagnosticsState* frame_diagnostics_state{};
     GraphicsController* graphics_controller{};
     MenuProperties* menu_properties{};
     KeyBindings* key_bindings{};

--- a/gui/include/gui_state_types.h
+++ b/gui/include/gui_state_types.h
@@ -76,9 +76,9 @@ struct KeyBindings
 
     SDL_Keycode load_game_rom = SDLK_O;
     SDL_Keycode fast_forward = SDLK_SPACE;
-    SDL_Keycode pause = SDLK_ESCAPE;
+    SDL_Keycode pause = SDLK_P;
     SDL_Keycode reset = SDLK_R;
-    SDL_Keycode fullscreen = SDLK_F11;
+    SDL_Keycode fullscreen = SDLK_F;
 
     void reset_to_defaults()
     {
@@ -93,9 +93,9 @@ struct KeyBindings
 
         load_game_rom = SDLK_O;
         fast_forward = SDLK_SPACE;
-        pause = SDLK_ESCAPE;
+        pause = SDLK_P;
         reset = SDLK_R;
-        fullscreen = SDLK_F11;
+        fullscreen = SDLK_F;
     }
 };
 

--- a/gui/include/gui_state_types.h
+++ b/gui/include/gui_state_types.h
@@ -155,6 +155,7 @@ struct RenderContext
     SDL_Texture* sdl_texture{};
     SDL_Window* sdl_window{};
     uint8_t* previously_published_frame_buffer_index{};
+    uint64_t* previously_published_frame_sequence_number{};
     std::string* loaded_game_rom_path{};
     std::string* loaded_boot_rom_path{};
     bool is_currently_rendering{};

--- a/gui/include/imgui_rendering.h
+++ b/gui/include/imgui_rendering.h
@@ -61,6 +61,20 @@ void render_error_message_popup(
     std::atomic<bool>& is_emulation_paused_atomic,
     std::string& error_message);
 
+void render_auxiliary_windows(
+    const uint8_t currently_published_frame_buffer_index,
+    GameBoyEmulator::Emulator& game_boy_emulator,
+    FileLoadingStatus& file_loading_status,
+    std::atomic<bool>& is_emulation_paused_atomic,
+    GraphicsController& graphics_controller,
+    MenuProperties& menu_properties,
+    KeyBindings& key_bindings,
+    std::string& error_message
+#ifndef __EMSCRIPTEN__
+    , FrameDiagnosticsState& frame_diagnostics_state
+#endif
+);
+
 std::string get_keybind_label(const SDL_Keycode key);
 
 ImVec4 get_imvec4_from_abgr(const uint32_t abgr);

--- a/gui/include/imgui_rendering.h
+++ b/gui/include/imgui_rendering.h
@@ -36,7 +36,7 @@ void render_main_menu_bar(
     MenuAndCursorDisplayStatus& fullscreen_display_status,
     GraphicsController& graphics_controller,
     MenuProperties& menu_properties,
-    KeyBindings& key_bindings,
+    const KeyBindings& key_bindings,
     SDL_Window* sdl_window,
     std::string* loaded_game_rom_path,
     std::string* loaded_boot_rom_path,
@@ -58,8 +58,8 @@ void render_error_message_popup(
     std::atomic<bool>& is_emulation_paused_atomic,
     std::string& error_message);
 
-std::string get_keybind_label(SDL_Keycode key);
+std::string get_keybind_label(const SDL_Keycode key);
 
-ImVec4 get_imvec4_from_abgr(uint32_t abgr);
+ImVec4 get_imvec4_from_abgr(const uint32_t abgr);
 
 void imgui_spaced_separator();

--- a/gui/include/imgui_rendering.h
+++ b/gui/include/imgui_rendering.h
@@ -34,6 +34,9 @@ void render_main_menu_bar(
     EmulationController& emulation_controller,
     FileLoadingStatus& file_loading_status,
     MenuAndCursorDisplayStatus& fullscreen_display_status,
+#ifndef __EMSCRIPTEN__
+    FrameDiagnosticsState& frame_diagnostics_state,
+#endif
     GraphicsController& graphics_controller,
     MenuProperties& menu_properties,
     const KeyBindings& key_bindings,

--- a/gui/include/input_events.h
+++ b/gui/include/input_events.h
@@ -16,6 +16,18 @@ bool try_load_file_to_memory_with_dialog(
     std::string* loaded_rom_path,
     std::string& error_message);
 
+#ifdef __EMSCRIPTEN__
+void consume_pending_web_file_selection(
+    GameBoyEmulator::Emulator& game_boy_emulator,
+    EmulationController& emulation_controller,
+    FileLoadingStatus& file_loading_status,
+    MenuAndCursorDisplayStatus& menu_and_cursor_display_status,
+    SDL_Window* sdl_window,
+    std::string* loaded_game_rom_path,
+    std::string* loaded_boot_rom_path,
+    std::string& error_message);
+#endif
+
 void toggle_emulation_paused_state(
     std::atomic<bool>& is_emulation_paused_atomic,
     float& seconds_until_main_menu_bar_and_cursor_hidden);

--- a/gui/include/raii_wrappers.h
+++ b/gui/include/raii_wrappers.h
@@ -86,11 +86,19 @@ public:
             throw std::runtime_error(std::string("SDL_CreateRenderer failed: ") + SDL_GetError());
         }
 
+#ifdef __EMSCRIPTEN__
+        SDL_SetRenderLogicalPresentation(
+            renderer,
+            display_width_pixels,
+            display_height_pixels,
+            SDL_LOGICAL_PRESENTATION_DISABLED);
+#else
         SDL_SetRenderLogicalPresentation(
             renderer,
             display_width_pixels,
             display_height_pixels,
             SDL_LOGICAL_PRESENTATION_INTEGER_SCALE);
+#endif
 
         if (!SDL_SetRenderVSync(renderer, 1))
         {

--- a/gui/include/raii_wrappers.h
+++ b/gui/include/raii_wrappers.h
@@ -86,19 +86,11 @@ public:
             throw std::runtime_error(std::string("SDL_CreateRenderer failed: ") + SDL_GetError());
         }
 
-#ifdef __EMSCRIPTEN__
-        SDL_SetRenderLogicalPresentation(
-            renderer,
-            display_width_pixels,
-            display_height_pixels,
-            SDL_LOGICAL_PRESENTATION_DISABLED);
-#else
         SDL_SetRenderLogicalPresentation(
             renderer,
             display_width_pixels,
             display_height_pixels,
             SDL_LOGICAL_PRESENTATION_INTEGER_SCALE);
-#endif
 
         if (!SDL_SetRenderVSync(renderer, 1))
         {

--- a/gui/include/raii_wrappers.h
+++ b/gui/include/raii_wrappers.h
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 #include <imgui_impl_sdlrenderer3.h>
+#ifndef __EMSCRIPTEN__
+#include <nfd.h>
+#endif
 #include <SDL3/SDL.h>
 #include <stdexcept>
 #include <string>
@@ -240,6 +243,7 @@ private:
     void* userdata_;
 };
 
+#ifndef __EMSCRIPTEN__
 class NfdInitializerRaii
 {
 public:
@@ -262,5 +266,6 @@ public:
     NfdInitializerRaii(NfdInitializerRaii&&) = delete;
     NfdInitializerRaii& operator=(NfdInitializerRaii&&) = delete;
 };
+#endif
 
 } // namespace ResourceAcquisitionIsInitialization

--- a/gui/include/web_main_loop.h
+++ b/gui/include/web_main_loop.h
@@ -36,6 +36,8 @@ struct EmscriptenLoopState
     uint64_t target_published_frame_sequence_number;
 };
 
+void sync_emscripten_canvas_to_viewport(SDL_Window* sdl_window, int viewport_w, int viewport_h);
+
 void start_emscripten_main_loop(EmscriptenLoopState& loop_state);
 
 #endif

--- a/gui/include/web_main_loop.h
+++ b/gui/include/web_main_loop.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <atomic>
+#include <exception>
+#include <string>
+#include <SDL3/SDL.h>
+
+#include "emulator.h"
+#include "gui_state_types.h"
+#include "persistent_settings.h"
+
+struct WebThreadPacingState
+{
+    std::atomic<uint64_t> target_published_frame_sequence_number_atomic{};
+};
+
+#ifdef __EMSCRIPTEN__
+
+struct EmscriptenLoopState
+{
+    GameBoyEmulator::Emulator* game_boy_emulator;
+    EmulationController* emulation_controller;
+    WebThreadPacingState* web_thread_pacing_state;
+    FileLoadingStatus* file_loading_status;
+    MenuAndCursorDisplayStatus* menu_and_cursor_display_status;
+    KeyPressedStates* key_pressed_states;
+    KeyBindings* key_bindings;
+    MenuProperties* menu_properties;
+    RenderContext* render_context;
+    std::atomic<bool>* did_emulator_core_exception_occur_atomic;
+    std::exception_ptr* emulator_core_exception_pointer;
+    PersistentSettings* persistent_settings;
+    bool* should_stop_emulation;
+    std::string* error_message;
+    SDL_Window* sdl_window;
+    uint64_t target_published_frame_sequence_number;
+};
+
+void start_emscripten_main_loop(EmscriptenLoopState& loop_state);
+
+#endif

--- a/gui/include/web_main_loop.h
+++ b/gui/include/web_main_loop.h
@@ -36,8 +36,6 @@ struct EmscriptenLoopState
     uint64_t target_published_frame_sequence_number;
 };
 
-void sync_emscripten_canvas_to_viewport(SDL_Window* sdl_window, int viewport_w, int viewport_h);
-
 void start_emscripten_main_loop(EmscriptenLoopState& loop_state);
 
 #endif

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -267,43 +267,6 @@ web_viewport_metrics_t get_web_viewport_metrics()
 
     return metrics;
 }
-
-void log_web_display_metrics(SDL_Window* sdl_window, const char* reason)
-{
-    const web_viewport_metrics_t metrics = get_web_viewport_metrics();
-
-    int sdl_window_width = 0;
-    int sdl_window_height = 0;
-    SDL_GetWindowSize(sdl_window, &sdl_window_width, &sdl_window_height);
-
-    EM_ASM(
-    {
-        console.info(
-            "[web-display]",
-            UTF8ToString($0),
-            {
-                css_viewport_width: $1,
-                css_viewport_height: $2,
-                pixel_viewport_width: $3,
-                pixel_viewport_height: $4,
-                device_pixel_ratio: $5,
-                sdl_window_width: $6,
-                sdl_window_height: $7,
-                canvas_client_width: Module.canvas ? Module.canvas.clientWidth : 0,
-                canvas_client_height: Module.canvas ? Module.canvas.clientHeight : 0,
-                canvas_width: Module.canvas ? Module.canvas.width : 0,
-                canvas_height: Module.canvas ? Module.canvas.height : 0
-            });
-    },
-    reason,
-    metrics.css_viewport_width,
-    metrics.css_viewport_height,
-    metrics.pixel_viewport_width,
-    metrics.pixel_viewport_height,
-    metrics.device_pixel_ratio,
-    sdl_window_width,
-    sdl_window_height);
-}
 #endif
 
 void render_frame(RenderContext& context)

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -62,78 +62,6 @@ static void update_frame_diagnostics(
     }
 }
 
-static void render_frame_diagnostics_overlay(FrameDiagnosticsState& frame_diagnostics_state)
-{
-    if (!frame_diagnostics_state.is_overlay_enabled)
-    {
-        return;
-    }
-
-    ImGui::SetNextWindowBgAlpha(0.75f);
-    ImGui::SetNextWindowPos(ImVec2(12.0f, 36.0f), ImGuiCond_FirstUseEver);
-
-    if (ImGui::Begin(
-            "Recent Performance",
-            &frame_diagnostics_state.is_overlay_enabled,
-            ImGuiWindowFlags_AlwaysAutoResize |
-            ImGuiWindowFlags_NoSavedSettings |
-            ImGuiWindowFlags_NoFocusOnAppearing))
-    {
-        constexpr float COLUMN_SPACING_WIDTH = 12.0f;
-        constexpr float VALUE_COLUMN_WIDTH = 160.0f;
-        const double displayed_emulator_frame_rate =
-            !frame_diagnostics_state.has_completed_sample &&
-            frame_diagnostics_state.sample_frame_count > 0 &&
-            frame_diagnostics_state.sample_elapsed_seconds > 0.0
-                ? static_cast<double>(frame_diagnostics_state.sample_emulator_frame_count) / frame_diagnostics_state.sample_elapsed_seconds
-                : frame_diagnostics_state.displayed_emulator_frame_rate;
-        const double displayed_worst_frame_time_ms =
-            !frame_diagnostics_state.has_completed_sample && frame_diagnostics_state.sample_frame_count > 0
-                ? frame_diagnostics_state.sample_worst_frame_time_ms
-                : frame_diagnostics_state.displayed_worst_frame_time_ms;
-        const uint32_t displayed_skipped_frame_count =
-            !frame_diagnostics_state.has_completed_sample && frame_diagnostics_state.sample_frame_count > 0
-                ? frame_diagnostics_state.sample_skipped_frame_count
-                : frame_diagnostics_state.displayed_skipped_frame_count;
-
-        if (ImGui::BeginTable(
-                "performance_overlay_table",
-                3,
-                ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoSavedSettings))
-        {
-            ImGui::TableSetupColumn("Metric");
-            ImGui::TableSetupColumn("Spacing", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, COLUMN_SPACING_WIDTH);
-            ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed, VALUE_COLUMN_WIDTH);
-
-            ImGui::TableNextRow();
-            ImGui::TableSetColumnIndex(0);
-            ImGui::TextUnformatted("Emulation FPS:");
-            ImGui::TableSetColumnIndex(1);
-            ImGui::TableSetColumnIndex(2);
-            const std::string emulation_fps_text = std::format("{:.2f}", displayed_emulator_frame_rate);
-            ImGui::TextUnformatted(emulation_fps_text.c_str());
-
-            ImGui::TableNextRow();
-            ImGui::TableSetColumnIndex(0);
-            ImGui::TextUnformatted("Worst Frame Time:");
-            ImGui::TableSetColumnIndex(1);
-            ImGui::TableSetColumnIndex(2);
-            const std::string worst_frame_time_text = std::format("{:.2f} ms", displayed_worst_frame_time_ms);
-            ImGui::TextUnformatted(worst_frame_time_text.c_str());
-
-            ImGui::TableNextRow();
-            ImGui::TableSetColumnIndex(0);
-            ImGui::TextUnformatted("Skipped Frames:");
-            ImGui::TableSetColumnIndex(1);
-            ImGui::TableSetColumnIndex(2);
-            const std::string skipped_frames_text = std::format("{}", displayed_skipped_frame_count);
-            ImGui::TextUnformatted(skipped_frames_text.c_str());
-
-            ImGui::EndTable();
-        }
-    }
-    ImGui::End();
-}
 #endif
 
 static bool is_cursor_currently_visible()
@@ -402,24 +330,19 @@ void render_frame(RenderContext& context)
         set_cursor_visible(false);
     }
 
-    render_custom_colour_palette_editor(
+    render_auxiliary_windows(
         currently_published_frame_buffer_index,
         *context.game_boy_emulator,
-        *context.menu_properties,
-        *context.graphics_controller);
-
-    render_keybinds_editor(
-        *context.menu_properties,
-        *context.key_bindings);
-
-    render_error_message_popup(
         *context.file_loading_status,
         context.emulation_controller->is_emulation_paused_atomic,
-        *context.error_message);
-
+        *context.graphics_controller,
+        *context.menu_properties,
+        *context.key_bindings,
+        *context.error_message
 #ifndef __EMSCRIPTEN__
-    render_frame_diagnostics_overlay(*context.frame_diagnostics_state);
+        , *context.frame_diagnostics_state
 #endif
+    );
 
     ImGui::Render();
     ImGui_ImplSDLRenderer3_RenderDrawData(ImGui::GetDrawData(), context.sdl_renderer);

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -1,5 +1,7 @@
 #include <backends/imgui_impl_sdlrenderer3.h>
 
+#include <cmath>
+
 #include "display_utilities.h"
 #include "imgui_rendering.h"
 
@@ -214,7 +216,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 
     const float display_height = 
 #ifdef __EMSCRIPTEN__
-        static_cast<float>(EM_ASM_DOUBLE({ return screen.height; }));
+        static_cast<float>(std::max(1, get_web_viewport_metrics().pixel_viewport_height));
 #else
         static_cast<float>(display_mode->h);
 #endif
@@ -237,6 +239,72 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
     style.FontScaleMain = font_scale;
 }
+
+#ifdef __EMSCRIPTEN__
+double get_web_device_pixel_ratio()
+{
+    const double device_pixel_ratio = EM_ASM_DOUBLE(
+    {
+        return window.devicePixelRatio || 1.0;
+    });
+
+    if (device_pixel_ratio > 0.0)
+    {
+        return device_pixel_ratio;
+    }
+
+    return 1.0;
+}
+
+web_viewport_metrics_t get_web_viewport_metrics()
+{
+    web_viewport_metrics_t metrics{};
+    metrics.css_viewport_width = EM_ASM_INT({ return window.innerWidth || 0; });
+    metrics.css_viewport_height = EM_ASM_INT({ return window.innerHeight || 0; });
+    metrics.device_pixel_ratio = get_web_device_pixel_ratio();
+    metrics.pixel_viewport_width = static_cast<int>(std::lround(static_cast<double>(metrics.css_viewport_width) * metrics.device_pixel_ratio));
+    metrics.pixel_viewport_height = static_cast<int>(std::lround(static_cast<double>(metrics.css_viewport_height) * metrics.device_pixel_ratio));
+
+    return metrics;
+}
+
+void log_web_display_metrics(SDL_Window* sdl_window, const char* reason)
+{
+    const web_viewport_metrics_t metrics = get_web_viewport_metrics();
+
+    int sdl_window_width = 0;
+    int sdl_window_height = 0;
+    SDL_GetWindowSize(sdl_window, &sdl_window_width, &sdl_window_height);
+
+    EM_ASM(
+    {
+        console.info(
+            "[web-display]",
+            UTF8ToString($0),
+            {
+                css_viewport_width: $1,
+                css_viewport_height: $2,
+                pixel_viewport_width: $3,
+                pixel_viewport_height: $4,
+                device_pixel_ratio: $5,
+                sdl_window_width: $6,
+                sdl_window_height: $7,
+                canvas_client_width: Module.canvas ? Module.canvas.clientWidth : 0,
+                canvas_client_height: Module.canvas ? Module.canvas.clientHeight : 0,
+                canvas_width: Module.canvas ? Module.canvas.width : 0,
+                canvas_height: Module.canvas ? Module.canvas.height : 0
+            });
+    },
+    reason,
+    metrics.css_viewport_width,
+    metrics.css_viewport_height,
+    metrics.pixel_viewport_width,
+    metrics.pixel_viewport_height,
+    metrics.device_pixel_ratio,
+    sdl_window_width,
+    sdl_window_height);
+}
+#endif
 
 void render_frame(RenderContext& context)
 {

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -9,15 +9,6 @@
 
 int get_initial_window_scale_for_display()
 {
-#ifdef __EMSCRIPTEN__
-    double dpr = emscripten_get_device_pixel_ratio();
-    int viewport_width = EM_ASM_INT({ return window.innerWidth; });
-    int viewport_height = EM_ASM_INT({ return window.innerHeight; });
-    // Scale to physical pixels so canvas buffer matches display resolution
-    return std::max(1, std::min(
-        static_cast<int>(viewport_width * dpr) / DISPLAY_WIDTH_PIXELS,
-        static_cast<int>(viewport_height * dpr) / DISPLAY_HEIGHT_PIXELS));
-#else
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
     if (display_mode != nullptr)
     {
@@ -28,7 +19,6 @@ int get_initial_window_scale_for_display()
         return static_cast<int>(DEFAULT_INITIAL_WINDOW_SCALE * scale_multiplier + 0.5f);
     }
     return DEFAULT_INITIAL_WINDOW_SCALE;
-#endif
 }
 
 void set_emulation_screen_blank(GraphicsController& graphics_controller)
@@ -77,6 +67,13 @@ bool should_main_menu_bar_and_cursor_be_visible(
     bool is_keybinds_editor_open,
     SDL_Window* sdl_window)
 {
+#ifdef __EMSCRIPTEN__
+    (void)sdl_window;
+    menu_and_cursor_display_status.seconds_until_main_menu_bar_and_cursor_hidden
+        = MAIN_MENU_BAR_AND_CURSOR_HIDE_DELAY_SECONDS;
+    return true;
+#endif
+
     if (!game_boy_emulator.is_game_rom_loaded_in_memory_thread_safe() ||
         emulation_controller.is_emulation_paused_atomic.load(std::memory_order_acquire) ||
         is_keybinds_editor_open ||
@@ -126,14 +123,15 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
         return;
     }
 
+    constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
+
 #ifdef __EMSCRIPTEN__
-    float display_height = static_cast<float>(EM_ASM_INT({ return screen.height * window.devicePixelRatio; }));
+    const float display_height = static_cast<float>(EM_ASM_DOUBLE({ return screen.height; }));
+    float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 #else
     float display_height = static_cast<float>(display_mode->h);
-#endif
-
-    constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
     float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
+#endif
 
     ImGuiStyle& style = ImGui::GetStyle();
 
@@ -166,6 +164,59 @@ void render_frame(RenderContext& context)
     {
         return;
     }
+
+#ifdef __EMSCRIPTEN__
+    {
+        ImGuiIO& io = ImGui::GetIO();
+        const double device_pixel_ratio = EM_ASM_DOUBLE({ return window.devicePixelRatio; });
+        const int canvas_width = EM_ASM_INT({ return document.getElementById('canvas').width; });
+        const int canvas_height = EM_ASM_INT({ return document.getElementById('canvas').height; });
+        const int canvas_css_width = EM_ASM_INT({ return Math.round(document.getElementById('canvas').getBoundingClientRect().width); });
+        const int canvas_css_height = EM_ASM_INT({ return Math.round(document.getElementById('canvas').getBoundingClientRect().height); });
+
+        static int previous_window_width = -1;
+        static int previous_window_height = -1;
+        static int previous_canvas_width = -1;
+        static int previous_canvas_height = -1;
+        static int previous_canvas_css_width = -1;
+        static int previous_canvas_css_height = -1;
+        static float previous_imgui_display_width = -1.0f;
+        static float previous_imgui_display_height = -1.0f;
+        static float previous_font_scale = -1.0f;
+
+        if (window_width != previous_window_width ||
+            window_height != previous_window_height ||
+            canvas_width != previous_canvas_width ||
+            canvas_height != previous_canvas_height ||
+            canvas_css_width != previous_canvas_css_width ||
+            canvas_css_height != previous_canvas_css_height ||
+            io.DisplaySize.x != previous_imgui_display_width ||
+            io.DisplaySize.y != previous_imgui_display_height ||
+            ImGui::GetStyle().FontScaleMain != previous_font_scale)
+        {
+            std::cout
+                << "[web-render] sdl=" << window_width << "x" << window_height
+                << " canvas=" << canvas_width << "x" << canvas_height
+                << " css=" << canvas_css_width << "x" << canvas_css_height
+                << " dpr=" << device_pixel_ratio
+                << " imgui_display=" << io.DisplaySize.x << "x" << io.DisplaySize.y
+                << " framebuffer_scale=" << io.DisplayFramebufferScale.x << "x" << io.DisplayFramebufferScale.y
+                << " font_scale=" << ImGui::GetStyle().FontScaleMain
+                << "\n";
+
+            previous_window_width = window_width;
+            previous_window_height = window_height;
+            previous_canvas_width = canvas_width;
+            previous_canvas_height = canvas_height;
+            previous_canvas_css_width = canvas_css_width;
+            previous_canvas_css_height = canvas_css_height;
+            previous_imgui_display_width = io.DisplaySize.x;
+            previous_imgui_display_height = io.DisplaySize.y;
+            previous_font_scale = ImGui::GetStyle().FontScaleMain;
+        }
+    }
+#endif
+
     context.is_currently_rendering = true;
     const uint8_t currently_published_frame_buffer_index = context.game_boy_emulator->get_published_frame_buffer_index_thread_safe();
 
@@ -186,6 +237,25 @@ void render_frame(RenderContext& context)
     }
 
     SDL_RenderClear(context.sdl_renderer);
+#ifdef __EMSCRIPTEN__
+    const float main_menu_bar_height_pixels = ImGui::GetFrameHeight();
+    const float available_height = std::max(0.0f, static_cast<float>(window_height) - main_menu_bar_height_pixels);
+    const int emulation_scale = std::max(
+        1,
+        std::min(
+            window_width / static_cast<int>(DISPLAY_WIDTH_PIXELS),
+            static_cast<int>(available_height) / static_cast<int>(DISPLAY_HEIGHT_PIXELS)));
+    const float emulation_width = static_cast<float>(DISPLAY_WIDTH_PIXELS * emulation_scale);
+    const float emulation_height = static_cast<float>(DISPLAY_HEIGHT_PIXELS * emulation_scale);
+    SDL_FRect emulation_screen_rectangle =
+        SDL_FRect
+        {
+            (static_cast<float>(window_width) - emulation_width) * 0.5f,
+            main_menu_bar_height_pixels + (available_height - emulation_height) * 0.5f,
+            emulation_width,
+            emulation_height
+        };
+#else
     SDL_FRect emulation_screen_rectangle =
         SDL_FRect
         {
@@ -194,12 +264,11 @@ void render_frame(RenderContext& context)
             static_cast<float>(DISPLAY_WIDTH_PIXELS),
             static_cast<float>(DISPLAY_HEIGHT_PIXELS)
         };
+#endif
     SDL_RenderTexture(context.sdl_renderer, context.sdl_texture, nullptr, &emulation_screen_rectangle);
 
     sdl_logical_presentation_imgui_workaround_t logical_values
         = sdl_logical_presentation_imgui_workaround_pre_frame(context.sdl_renderer);
-
-    update_imgui_scale_by_resolution(context.sdl_window);
 
     ImGui_ImplSDL3_NewFrame();
     ImGui_ImplSDLRenderer3_NewFrame();

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -1,4 +1,5 @@
 #include <backends/imgui_impl_sdlrenderer3.h>
+#include <iostream>
 
 #include "display_utilities.h"
 #include "imgui_rendering.h"
@@ -217,6 +218,11 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     }
 
     const float display_height = static_cast<float>(browser_window_height);
+    const double browser_inner_height = EM_ASM_DOUBLE({ return window.innerHeight || 0; });
+    const double browser_device_pixel_ratio = EM_ASM_DOUBLE({ return window.devicePixelRatio || 1; });
+    int window_width = 0;
+    int window_height = 0;
+    SDL_GetWindowSize(sdl_window, &window_width, &window_height);
 #else
     SDL_DisplayID display_id = SDL_GetDisplayForWindow(sdl_window);
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(display_id);
@@ -229,6 +235,32 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     const float display_height = static_cast<float>(display_mode->h);
 #endif
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
+
+#ifdef __EMSCRIPTEN__
+    static float previous_logged_display_height = -1.0f;
+    static float previous_logged_font_scale = -1.0f;
+    static int previous_logged_window_width = -1;
+    static int previous_logged_window_height = -1;
+
+    if (previous_logged_display_height != display_height ||
+        previous_logged_font_scale != font_scale ||
+        previous_logged_window_width != window_width ||
+        previous_logged_window_height != window_height)
+    {
+        previous_logged_display_height = display_height;
+        previous_logged_font_scale = font_scale;
+        previous_logged_window_width = window_width;
+        previous_logged_window_height = window_height;
+
+        std::cout << "[web_scale] outer_height=" << browser_window_height
+                  << " inner_height=" << browser_inner_height
+                  << " device_pixel_ratio=" << browser_device_pixel_ratio
+                  << " sdl_window_width=" << window_width
+                  << " sdl_window_height=" << window_height
+                  << " display_height=" << display_height
+                  << " font_scale=" << font_scale << "\n";
+    }
+#endif
 
     ImGuiStyle& style = ImGui::GetStyle();
 

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -1,5 +1,4 @@
 #include <backends/imgui_impl_sdlrenderer3.h>
-#include <iostream>
 
 #include "display_utilities.h"
 #include "imgui_rendering.h"
@@ -218,11 +217,6 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     }
 
     const float display_height = static_cast<float>(browser_window_height);
-    const double browser_inner_height = EM_ASM_DOUBLE({ return window.innerHeight || 0; });
-    const double browser_device_pixel_ratio = EM_ASM_DOUBLE({ return window.devicePixelRatio || 1; });
-    int window_width = 0;
-    int window_height = 0;
-    SDL_GetWindowSize(sdl_window, &window_width, &window_height);
 #else
     SDL_DisplayID display_id = SDL_GetDisplayForWindow(sdl_window);
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(display_id);
@@ -235,32 +229,6 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     const float display_height = static_cast<float>(display_mode->h);
 #endif
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
-
-#ifdef __EMSCRIPTEN__
-    static float previous_logged_display_height = -1.0f;
-    static float previous_logged_font_scale = -1.0f;
-    static int previous_logged_window_width = -1;
-    static int previous_logged_window_height = -1;
-
-    if (previous_logged_display_height != display_height ||
-        previous_logged_font_scale != font_scale ||
-        previous_logged_window_width != window_width ||
-        previous_logged_window_height != window_height)
-    {
-        previous_logged_display_height = display_height;
-        previous_logged_font_scale = font_scale;
-        previous_logged_window_width = window_width;
-        previous_logged_window_height = window_height;
-
-        std::cout << "[web_scale] outer_height=" << browser_window_height
-                  << " inner_height=" << browser_inner_height
-                  << " device_pixel_ratio=" << browser_device_pixel_ratio
-                  << " sdl_window_width=" << window_width
-                  << " sdl_window_height=" << window_height
-                  << " display_height=" << display_height
-                  << " font_scale=" << font_scale << "\n";
-    }
-#endif
 
     ImGuiStyle& style = ImGui::GetStyle();
 

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -7,6 +7,38 @@
 #include <emscripten.h>
 #endif
 
+static bool is_cursor_currently_visible()
+{
+#ifdef __EMSCRIPTEN__
+    return EM_ASM_INT(
+    {
+        return Module.isWebCursorVisible ? 1 : 0;
+    }) != 0;
+#else
+    return SDL_CursorVisible();
+#endif
+}
+
+static void set_cursor_visible(const bool is_visible)
+{
+#ifdef __EMSCRIPTEN__
+    EM_ASM(
+    {
+        Module.setWebCursorVisible(!!$0);
+    },
+    is_visible ? 1 : 0);
+#else
+    if (is_visible)
+    {
+        SDL_ShowCursor();
+    }
+    else
+    {
+        SDL_HideCursor();
+    }
+#endif
+}
+
 int get_initial_window_scale_for_display()
 {
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
@@ -67,13 +99,7 @@ bool should_main_menu_bar_and_cursor_be_visible(
     bool is_keybinds_editor_open,
     SDL_Window* sdl_window)
 {
-#ifdef __EMSCRIPTEN__
     (void)sdl_window;
-    menu_and_cursor_display_status.seconds_until_main_menu_bar_and_cursor_hidden
-        = MAIN_MENU_BAR_AND_CURSOR_HIDE_DELAY_SECONDS;
-    return true;
-#endif
-
     if (!game_boy_emulator.is_game_rom_loaded_in_memory_thread_safe() ||
         emulation_controller.is_emulation_paused_atomic.load(std::memory_order_acquire) ||
         is_keybinds_editor_open ||
@@ -84,11 +110,17 @@ bool should_main_menu_bar_and_cursor_be_visible(
         return true;
     }
 
-    float mouse_y_position_in_window;
-    SDL_GetGlobalMouseState(nullptr, &mouse_y_position_in_window);
-    const float main_menu_bar_height_pixels = ImGui::GetFrameHeight() * ImGui::GetIO().DisplayFramebufferScale.y;
     ImGuiIO& io = ImGui::GetIO();
-    if (SDL_GetMouseFocus() == sdl_window)
+    const float main_menu_bar_height_pixels = ImGui::GetFrameHeight() * io.DisplayFramebufferScale.y;
+    const bool is_mouse_position_valid = ImGui::IsMousePosValid(&io.MousePos);
+    const bool is_mouse_in_window =
+        is_mouse_position_valid &&
+        io.MousePos.x >= 0.0f &&
+        io.MousePos.y >= 0.0f &&
+        io.MousePos.x < io.DisplaySize.x &&
+        io.MousePos.y < io.DisplaySize.y;
+
+    if (is_mouse_in_window)
     {
         if (menu_and_cursor_display_status.cursor_changes_to_ignore_count != 0)
         {
@@ -96,13 +128,13 @@ bool should_main_menu_bar_and_cursor_be_visible(
             return false;
         }
         else if (menu_and_cursor_display_status.is_main_menu_bar_hovered ||
-                mouse_y_position_in_window <= main_menu_bar_height_pixels ||
+                io.MousePos.y <= main_menu_bar_height_pixels ||
                 io.MouseDelta.x != 0.0f ||
                 io.MouseDelta.y != 0.0f)
         {
-                menu_and_cursor_display_status.seconds_until_main_menu_bar_and_cursor_hidden
-                    = MAIN_MENU_BAR_AND_CURSOR_HIDE_DELAY_SECONDS;
-                return true;
+            menu_and_cursor_display_status.seconds_until_main_menu_bar_and_cursor_hidden
+                = MAIN_MENU_BAR_AND_CURSOR_HIDE_DELAY_SECONDS;
+            return true;
         }
     }
 
@@ -208,9 +240,9 @@ void render_frame(RenderContext& context)
             context.menu_properties->keybinds_editor_state.is_open,
             context.sdl_window))
     {
-        if (!SDL_CursorVisible())
+        if (!is_cursor_currently_visible())
         {
-            SDL_ShowCursor();
+            set_cursor_visible(true);
         }
         render_main_menu_bar(
             currently_published_frame_buffer_index,
@@ -227,9 +259,9 @@ void render_frame(RenderContext& context)
             *context.should_stop_emulation,
             *context.error_message);
     }
-    else if (SDL_CursorVisible())
+    else if (is_cursor_currently_visible())
     {
-        SDL_HideCursor();
+        set_cursor_visible(false);
     }
 
     render_custom_colour_palette_editor(

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -326,13 +326,13 @@ void render_frame(RenderContext& context)
 
     context.is_currently_rendering = true;
     const uint8_t currently_published_frame_buffer_index = context.game_boy_emulator->get_published_frame_buffer_index_thread_safe();
+    const uint64_t current_published_frame_sequence_number = context.game_boy_emulator->get_published_frame_sequence_number_thread_safe();
 
 #ifndef __EMSCRIPTEN__
-    const uint64_t current_published_frame_sequence_number = context.game_boy_emulator->get_published_frame_sequence_number_thread_safe();
     update_frame_diagnostics(*context.frame_diagnostics_state, current_published_frame_sequence_number);
 #endif
 
-    if (currently_published_frame_buffer_index != *context.previously_published_frame_buffer_index)
+    if (current_published_frame_sequence_number != *context.previously_published_frame_sequence_number)
     {
         auto const& pixel_frame_buffer = context.game_boy_emulator->get_pixel_frame_buffer(currently_published_frame_buffer_index);
 
@@ -346,6 +346,7 @@ void render_frame(RenderContext& context)
             context.graphics_controller->abgr_pixel_buffer.get(),
             DISPLAY_WIDTH_PIXELS * sizeof(uint32_t));
         *context.previously_published_frame_buffer_index = currently_published_frame_buffer_index;
+        *context.previously_published_frame_sequence_number = current_published_frame_sequence_number;
     }
 
     SDL_RenderClear(context.sdl_renderer);

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -20,14 +20,19 @@ static void refresh_web_imgui_font_if_needed(
     const float target_font_size = std::max(
         1.0f,
         std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale * device_pixel_ratio));
+    const float font_size_ratio = BASE_IMGUI_FONT_SIZE_PIXELS * font_scale / target_font_size;
     static float previous_loaded_font_size = 0.0f;
+    static float previous_font_size_ratio = 0.0f;
 
-    if (io.FontDefault != nullptr && previous_loaded_font_size == target_font_size)
+    if (io.FontDefault != nullptr &&
+        previous_loaded_font_size == target_font_size &&
+        previous_font_size_ratio == font_size_ratio)
     {
         return;
     }
 
     previous_loaded_font_size = target_font_size;
+    previous_font_size_ratio = font_size_ratio;
 
     ImFontConfig font_config;
     font_config.FontDataOwnedByAtlas = false;
@@ -45,6 +50,7 @@ static void refresh_web_imgui_font_if_needed(
 
     std::cout << "[web_font] target_font_size=" << target_font_size
               << " font_scale=" << font_scale
+              << " font_size_ratio=" << font_size_ratio
               << " device_pixel_ratio=" << device_pixel_ratio << "\n";
 }
 #endif
@@ -263,7 +269,10 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     const double browser_device_pixel_ratio = EM_ASM_DOUBLE({ return window.devicePixelRatio || 1; });
     int window_width = 0;
     int window_height = 0;
+    int window_pixel_width = 0;
+    int window_pixel_height = 0;
     SDL_GetWindowSize(sdl_window, &window_width, &window_height);
+    SDL_GetWindowSizeInPixels(sdl_window, &window_pixel_width, &window_pixel_height);
 #else
     SDL_DisplayID display_id = SDL_GetDisplayForWindow(sdl_window);
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(display_id);
@@ -280,28 +289,43 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 #ifdef __EMSCRIPTEN__
     refresh_web_imgui_font_if_needed(font_scale, static_cast<float>(browser_device_pixel_ratio));
 
+    const float loaded_font_size = std::max(1.0f, std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale * static_cast<float>(browser_device_pixel_ratio)));
+    const float font_scale_main = (BASE_IMGUI_FONT_SIZE_PIXELS * font_scale) / loaded_font_size;
+
     static float previous_logged_display_height = -1.0f;
     static float previous_logged_font_scale = -1.0f;
     static int previous_logged_window_width = -1;
     static int previous_logged_window_height = -1;
+    static int previous_logged_window_pixel_width = -1;
+    static int previous_logged_window_pixel_height = -1;
+    static float previous_logged_font_scale_main = -1.0f;
 
     if (previous_logged_display_height != display_height ||
         previous_logged_font_scale != font_scale ||
         previous_logged_window_width != window_width ||
-        previous_logged_window_height != window_height)
+        previous_logged_window_height != window_height ||
+        previous_logged_window_pixel_width != window_pixel_width ||
+        previous_logged_window_pixel_height != window_pixel_height ||
+        previous_logged_font_scale_main != font_scale_main)
     {
         previous_logged_display_height = display_height;
         previous_logged_font_scale = font_scale;
         previous_logged_window_width = window_width;
         previous_logged_window_height = window_height;
+        previous_logged_window_pixel_width = window_pixel_width;
+        previous_logged_window_pixel_height = window_pixel_height;
+        previous_logged_font_scale_main = font_scale_main;
 
         std::cout << "[web_scale] viewport_height=" << browser_window_height
                   << " inner_height=" << browser_inner_height
                   << " device_pixel_ratio=" << browser_device_pixel_ratio
                   << " sdl_window_width=" << window_width
                   << " sdl_window_height=" << window_height
+                  << " sdl_window_pixel_width=" << window_pixel_width
+                  << " sdl_window_pixel_height=" << window_pixel_height
                   << " display_height=" << display_height
-                  << " font_scale=" << font_scale << "\n";
+                  << " font_scale=" << font_scale
+                  << " font_scale_main=" << font_scale_main << "\n";
     }
 #endif
 
@@ -321,7 +345,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     style.ItemInnerSpacing = ImVec2(BASE_ITEM_INNER_SPACING_X * font_scale, BASE_ITEM_INNER_SPACING_Y * font_scale);
     style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
 #ifdef __EMSCRIPTEN__
-    style.FontScaleMain = 1.0f / static_cast<float>(browser_device_pixel_ratio);
+    style.FontScaleMain = font_scale_main;
 #else
     style.FontScaleMain = font_scale;
 #endif

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -3,8 +3,19 @@
 #include "display_utilities.h"
 #include "imgui_rendering.h"
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 int get_initial_window_scale_for_display()
 {
+#ifdef __EMSCRIPTEN__
+    const int viewport_width = EM_ASM_INT({ return window.innerWidth; });
+    const int viewport_height = EM_ASM_INT({ return window.innerHeight; });
+    return std::max(1, std::min(
+        viewport_width / DISPLAY_WIDTH_PIXELS,
+        viewport_height / DISPLAY_HEIGHT_PIXELS));
+#else
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
     if (display_mode != nullptr)
     {
@@ -15,6 +26,7 @@ int get_initial_window_scale_for_display()
         return static_cast<int>(DEFAULT_INITIAL_WINDOW_SCALE * scale_multiplier + 0.5f);
     }
     return DEFAULT_INITIAL_WINDOW_SCALE;
+#endif
 }
 
 void set_emulation_screen_blank(GraphicsController& graphics_controller)

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -209,7 +209,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 #ifdef __EMSCRIPTEN__
     const double browser_window_height = EM_ASM_DOUBLE(
     {
-        return window.outerHeight || window.screen.height;
+        return window.innerHeight * (window.devicePixelRatio || 1);
     });
 
     if (browser_window_height <= 0.0)
@@ -252,7 +252,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
         previous_logged_window_width = window_width;
         previous_logged_window_height = window_height;
 
-        std::cout << "[web_scale] outer_height=" << browser_window_height
+        std::cout << "[web_scale] viewport_pixel_height=" << browser_window_height
                   << " inner_height=" << browser_inner_height
                   << " device_pixel_ratio=" << browser_device_pixel_ratio
                   << " sdl_window_width=" << window_width

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -1,47 +1,11 @@
-#include <algorithm>
 #include <backends/imgui_impl_sdlrenderer3.h>
-#include <cmath>
 #include <iostream>
 
-#include "carlito_embedded.h"
 #include "display_utilities.h"
 #include "imgui_rendering.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-
-constexpr float BASE_IMGUI_FONT_SIZE_PIXELS = 20.0f;
-
-static void refresh_web_imgui_font_if_needed(const float font_scale)
-{
-    ImGuiIO& io = ImGui::GetIO();
-    const float target_font_size = std::max(1.0f, std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale));
-    static float previous_loaded_font_size = 0.0f;
-
-    if (io.FontDefault != nullptr && previous_loaded_font_size == target_font_size)
-    {
-        return;
-    }
-
-    previous_loaded_font_size = target_font_size;
-
-    ImFontConfig font_config;
-    font_config.FontDataOwnedByAtlas = false;
-
-    io.Fonts->Clear();
-    io.FontDefault = io.Fonts->AddFontFromMemoryTTF(
-        const_cast<unsigned char*>(carlito_ttf),
-        carlito_ttf_len,
-        target_font_size,
-        &font_config);
-    io.Fonts->Build();
-
-    ImGui_ImplSDLRenderer3_DestroyFontsTexture();
-    ImGui_ImplSDLRenderer3_CreateFontsTexture();
-
-    std::cout << "[web_font] target_font_size=" << target_font_size
-              << " font_scale=" << font_scale << "\n";
-}
 #endif
 
 #ifndef __EMSCRIPTEN__
@@ -273,8 +237,6 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 
 #ifdef __EMSCRIPTEN__
-    refresh_web_imgui_font_if_needed(font_scale);
-
     static float previous_logged_display_height = -1.0f;
     static float previous_logged_font_scale = -1.0f;
     static int previous_logged_window_width = -1;
@@ -315,11 +277,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     style.ItemSpacing = ImVec2(BASE_ITEM_SPACING_X * font_scale, BASE_ITEM_SPACING_Y * font_scale);
     style.ItemInnerSpacing = ImVec2(BASE_ITEM_INNER_SPACING_X * font_scale, BASE_ITEM_INNER_SPACING_Y * font_scale);
     style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
-#ifdef __EMSCRIPTEN__
-    style.FontScaleMain = 1.0f;
-#else
     style.FontScaleMain = font_scale;
-#endif
 }
 
 void render_frame(RenderContext& context)

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -36,8 +36,8 @@ static void refresh_web_imgui_font_if_needed(const float font_scale)
         &font_config);
     io.Fonts->Build();
 
-    ImGui_ImplSDLRenderer3_DestroyFontsTexture();
-    ImGui_ImplSDLRenderer3_CreateFontsTexture();
+    ImGui_ImplSDLRenderer3_DestroyDeviceObjects();
+    ImGui_ImplSDLRenderer3_CreateDeviceObjects();
 
     std::cout << "[web_font] target_font_size=" << target_font_size
               << " font_scale=" << font_scale << "\n";

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -7,6 +7,135 @@
 #include <emscripten.h>
 #endif
 
+#ifndef __EMSCRIPTEN__
+static void update_frame_diagnostics(
+    FrameDiagnosticsState& frame_diagnostics_state,
+    uint64_t current_published_frame_sequence_number)
+{
+    if (frame_diagnostics_state.performance_counter_frequency == 0)
+    {
+        return;
+    }
+
+    const uint64_t current_frame_counter = SDL_GetPerformanceCounter();
+    if (frame_diagnostics_state.previous_frame_counter == 0)
+    {
+        frame_diagnostics_state.previous_frame_counter = current_frame_counter;
+        frame_diagnostics_state.previous_published_frame_sequence_number = current_published_frame_sequence_number;
+        return;
+    }
+
+    const double frame_time_seconds = static_cast<double>(current_frame_counter - frame_diagnostics_state.previous_frame_counter)
+        / static_cast<double>(frame_diagnostics_state.performance_counter_frequency);
+    frame_diagnostics_state.previous_frame_counter = current_frame_counter;
+
+    const double frame_time_ms = frame_time_seconds * 1000.0;
+    frame_diagnostics_state.sample_elapsed_seconds += frame_time_seconds;
+    frame_diagnostics_state.sample_worst_frame_time_ms = std::max(frame_diagnostics_state.sample_worst_frame_time_ms, frame_time_ms);
+    frame_diagnostics_state.sample_frame_count++;
+
+    if (current_published_frame_sequence_number > frame_diagnostics_state.previous_published_frame_sequence_number)
+    {
+        const uint64_t published_frame_delta =
+            current_published_frame_sequence_number - frame_diagnostics_state.previous_published_frame_sequence_number;
+        frame_diagnostics_state.sample_emulator_frame_count += static_cast<uint32_t>(published_frame_delta);
+        if (published_frame_delta > 1)
+        {
+            frame_diagnostics_state.sample_skipped_frame_count += static_cast<uint32_t>(published_frame_delta - 1);
+        }
+    }
+
+    frame_diagnostics_state.previous_published_frame_sequence_number = current_published_frame_sequence_number;
+
+    if (frame_diagnostics_state.sample_elapsed_seconds >= FrameDiagnosticsState::SAMPLE_WINDOW_SECONDS)
+    {
+        frame_diagnostics_state.displayed_worst_frame_time_ms = frame_diagnostics_state.sample_worst_frame_time_ms;
+        frame_diagnostics_state.displayed_emulator_frame_rate =
+            static_cast<double>(frame_diagnostics_state.sample_emulator_frame_count) / frame_diagnostics_state.sample_elapsed_seconds;
+        frame_diagnostics_state.displayed_skipped_frame_count = frame_diagnostics_state.sample_skipped_frame_count;
+        frame_diagnostics_state.has_completed_sample = true;
+        frame_diagnostics_state.sample_elapsed_seconds = 0.0;
+        frame_diagnostics_state.sample_worst_frame_time_ms = 0.0;
+        frame_diagnostics_state.sample_frame_count = 0;
+        frame_diagnostics_state.sample_emulator_frame_count = 0;
+        frame_diagnostics_state.sample_skipped_frame_count = 0;
+    }
+}
+
+static void render_frame_diagnostics_overlay(FrameDiagnosticsState& frame_diagnostics_state)
+{
+    if (!frame_diagnostics_state.is_overlay_enabled)
+    {
+        return;
+    }
+
+    ImGui::SetNextWindowBgAlpha(0.75f);
+    ImGui::SetNextWindowPos(ImVec2(12.0f, 36.0f), ImGuiCond_FirstUseEver);
+
+    if (ImGui::Begin(
+            "Recent Performance",
+            &frame_diagnostics_state.is_overlay_enabled,
+            ImGuiWindowFlags_AlwaysAutoResize |
+            ImGuiWindowFlags_NoSavedSettings |
+            ImGuiWindowFlags_NoFocusOnAppearing))
+    {
+        constexpr float COLUMN_SPACING_WIDTH = 12.0f;
+        constexpr float VALUE_COLUMN_WIDTH = 160.0f;
+        const double displayed_emulator_frame_rate =
+            !frame_diagnostics_state.has_completed_sample &&
+            frame_diagnostics_state.sample_frame_count > 0 &&
+            frame_diagnostics_state.sample_elapsed_seconds > 0.0
+                ? static_cast<double>(frame_diagnostics_state.sample_emulator_frame_count) / frame_diagnostics_state.sample_elapsed_seconds
+                : frame_diagnostics_state.displayed_emulator_frame_rate;
+        const double displayed_worst_frame_time_ms =
+            !frame_diagnostics_state.has_completed_sample && frame_diagnostics_state.sample_frame_count > 0
+                ? frame_diagnostics_state.sample_worst_frame_time_ms
+                : frame_diagnostics_state.displayed_worst_frame_time_ms;
+        const uint32_t displayed_skipped_frame_count =
+            !frame_diagnostics_state.has_completed_sample && frame_diagnostics_state.sample_frame_count > 0
+                ? frame_diagnostics_state.sample_skipped_frame_count
+                : frame_diagnostics_state.displayed_skipped_frame_count;
+
+        if (ImGui::BeginTable(
+                "performance_overlay_table",
+                3,
+                ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoSavedSettings))
+        {
+            ImGui::TableSetupColumn("Metric");
+            ImGui::TableSetupColumn("Spacing", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, COLUMN_SPACING_WIDTH);
+            ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed, VALUE_COLUMN_WIDTH);
+
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted("Emulation FPS:");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TableSetColumnIndex(2);
+            const std::string emulation_fps_text = std::format("{:.2f}", displayed_emulator_frame_rate);
+            ImGui::TextUnformatted(emulation_fps_text.c_str());
+
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted("Worst Frame Time:");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TableSetColumnIndex(2);
+            const std::string worst_frame_time_text = std::format("{:.2f} ms", displayed_worst_frame_time_ms);
+            ImGui::TextUnformatted(worst_frame_time_text.c_str());
+
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted("Skipped Frames:");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TableSetColumnIndex(2);
+            const std::string skipped_frames_text = std::format("{}", displayed_skipped_frame_count);
+            ImGui::TextUnformatted(skipped_frames_text.c_str());
+
+            ImGui::EndTable();
+        }
+    }
+    ImGui::End();
+}
+#endif
+
 static bool is_cursor_currently_visible()
 {
 #ifdef __EMSCRIPTEN__
@@ -198,6 +327,11 @@ void render_frame(RenderContext& context)
     context.is_currently_rendering = true;
     const uint8_t currently_published_frame_buffer_index = context.game_boy_emulator->get_published_frame_buffer_index_thread_safe();
 
+#ifndef __EMSCRIPTEN__
+    const uint64_t current_published_frame_sequence_number = context.game_boy_emulator->get_published_frame_sequence_number_thread_safe();
+    update_frame_diagnostics(*context.frame_diagnostics_state, current_published_frame_sequence_number);
+#endif
+
     if (currently_published_frame_buffer_index != *context.previously_published_frame_buffer_index)
     {
         auto const& pixel_frame_buffer = context.game_boy_emulator->get_pixel_frame_buffer(currently_published_frame_buffer_index);
@@ -250,6 +384,9 @@ void render_frame(RenderContext& context)
             *context.emulation_controller,
             *context.file_loading_status,
             *context.menu_and_cursor_display_status,
+#ifndef __EMSCRIPTEN__
+            *context.frame_diagnostics_state,
+#endif
             *context.graphics_controller,
             *context.menu_properties,
             *context.key_bindings,
@@ -278,6 +415,10 @@ void render_frame(RenderContext& context)
         *context.file_loading_status,
         context.emulation_controller->is_emulation_paused_atomic,
         *context.error_message);
+
+#ifndef __EMSCRIPTEN__
+    render_frame_diagnostics_overlay(*context.frame_diagnostics_state);
+#endif
 
     ImGui::Render();
     ImGui_ImplSDLRenderer3_RenderDrawData(ImGui::GetDrawData(), context.sdl_renderer);

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -70,9 +70,9 @@ static bool is_cursor_currently_visible()
 {
 #ifdef __EMSCRIPTEN__
     return EM_ASM_INT(
-    {
-        return Module.is_web_cursor_visible ? 1 : 0;
-    }) != 0;
+        {
+            return Module.is_web_cursor_visible ? 1 : 0; 
+        }) != 0;
 #else
     return SDL_CursorVisible();
 #endif
@@ -82,10 +82,10 @@ static void set_cursor_visible(const bool is_visible)
 {
 #ifdef __EMSCRIPTEN__
     EM_ASM(
-    {
-        Module.setWebCursorVisible(!!$0);
-    },
-    is_visible ? 1 : 0);
+        {
+            Module.setWebCursorVisible(!!$0);
+        },
+        is_visible ? 1 : 0);
 #else
     if (is_visible)
     {
@@ -155,10 +155,8 @@ bool should_main_menu_bar_and_cursor_be_visible(
     const EmulationController& emulation_controller,
     MenuAndCursorDisplayStatus& menu_and_cursor_display_status,
     bool is_custom_palette_editor_open,
-    bool is_keybinds_editor_open,
-    SDL_Window* sdl_window)
+    bool is_keybinds_editor_open)
 {
-    (void)sdl_window;
     if (!game_boy_emulator.is_game_rom_loaded_in_memory_thread_safe() ||
         emulation_controller.is_emulation_paused_atomic.load(std::memory_order_acquire) ||
         is_keybinds_editor_open ||
@@ -214,11 +212,10 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     }
     constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
 
-    const float display_height = 
 #ifdef __EMSCRIPTEN__
-        static_cast<float>(std::max(1, get_web_viewport_metrics().pixel_viewport_height));
+    const float display_height = static_cast<float>(std::max(1, get_web_viewport_metrics().pixel_viewport_height));
 #else
-        static_cast<float>(display_mode->h);
+    const float display_height = static_cast<float>(display_mode->h);
 #endif
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 
@@ -331,8 +328,7 @@ void render_frame(RenderContext& context)
             *context.emulation_controller,
             *context.menu_and_cursor_display_status,
             context.menu_properties->is_custom_palette_editor_open,
-            context.menu_properties->keybinds_editor_state.is_open,
-            context.sdl_window))
+            context.menu_properties->keybinds_editor_state.is_open))
     {
         if (!is_cursor_currently_visible())
         {

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -36,8 +36,8 @@ static void refresh_web_imgui_font_if_needed(const float font_scale)
         &font_config);
     io.Fonts->Build();
 
-    ImGui_ImplSDLRenderer3_DestroyDeviceObjects();
-    ImGui_ImplSDLRenderer3_CreateDeviceObjects();
+    ImGui_ImplSDLRenderer3_DestroyFontsTexture();
+    ImGui_ImplSDLRenderer3_CreateFontsTexture();
 
     std::cout << "[web_font] target_font_size=" << target_font_size
               << " font_scale=" << font_scale << "\n";

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -12,10 +12,14 @@
 
 constexpr float BASE_IMGUI_FONT_SIZE_PIXELS = 20.0f;
 
-static void refresh_web_imgui_font_if_needed(const float font_scale)
+static void refresh_web_imgui_font_if_needed(
+    const float font_scale,
+    const float device_pixel_ratio)
 {
     ImGuiIO& io = ImGui::GetIO();
-    const float target_font_size = std::max(1.0f, std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale));
+    const float target_font_size = std::max(
+        1.0f,
+        std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale * device_pixel_ratio));
     static float previous_loaded_font_size = 0.0f;
 
     if (io.FontDefault != nullptr && previous_loaded_font_size == target_font_size)
@@ -40,7 +44,8 @@ static void refresh_web_imgui_font_if_needed(const float font_scale)
     ImGui_ImplSDLRenderer3_CreateDeviceObjects();
 
     std::cout << "[web_font] target_font_size=" << target_font_size
-              << " font_scale=" << font_scale << "\n";
+              << " font_scale=" << font_scale
+              << " device_pixel_ratio=" << device_pixel_ratio << "\n";
 }
 #endif
 
@@ -273,7 +278,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 
 #ifdef __EMSCRIPTEN__
-    refresh_web_imgui_font_if_needed(font_scale);
+    refresh_web_imgui_font_if_needed(font_scale, static_cast<float>(browser_device_pixel_ratio));
 
     static float previous_logged_display_height = -1.0f;
     static float previous_logged_font_scale = -1.0f;
@@ -316,7 +321,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     style.ItemInnerSpacing = ImVec2(BASE_ITEM_INNER_SPACING_X * font_scale, BASE_ITEM_INNER_SPACING_Y * font_scale);
     style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
 #ifdef __EMSCRIPTEN__
-    style.FontScaleMain = 1.0f;
+    style.FontScaleMain = 1.0f / static_cast<float>(browser_device_pixel_ratio);
 #else
     style.FontScaleMain = font_scale;
 #endif

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -241,9 +241,8 @@ bool should_main_menu_bar_and_cursor_be_visible(
 
     ImGuiIO& io = ImGui::GetIO();
     const float main_menu_bar_height_pixels = ImGui::GetFrameHeight() * io.DisplayFramebufferScale.y;
-    const bool is_mouse_position_valid = ImGui::IsMousePosValid(&io.MousePos);
     const bool is_mouse_in_window =
-        is_mouse_position_valid &&
+        ImGui::IsMousePosValid(&io.MousePos) &&
         io.MousePos.x >= 0.0f &&
         io.MousePos.y >= 0.0f &&
         io.MousePos.x < io.DisplaySize.x &&
@@ -285,10 +284,11 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     }
     constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
 
+    const float display_height = 
 #ifdef __EMSCRIPTEN__
-    const float display_height = static_cast<float>(EM_ASM_DOUBLE({ return screen.height; }));
+        static_cast<float>(EM_ASM_DOUBLE({ return screen.height; }));
 #else
-    const float display_height = static_cast<float>(display_mode->h);
+        static_cast<float>(display_mode->h);
 #endif
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -60,7 +60,7 @@ void update_colour_palette(
 }
 
 bool should_main_menu_bar_and_cursor_be_visible(
-    GameBoyEmulator::Emulator& game_boy_emulator,
+    const GameBoyEmulator::Emulator& game_boy_emulator,
     const EmulationController& emulation_controller,
     MenuAndCursorDisplayStatus& menu_and_cursor_display_status,
     bool is_custom_palette_editor_open,
@@ -122,16 +122,14 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     {
         return;
     }
-
     constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
 
 #ifdef __EMSCRIPTEN__
     const float display_height = static_cast<float>(EM_ASM_DOUBLE({ return screen.height; }));
-    float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 #else
-    float display_height = static_cast<float>(display_mode->h);
-    float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
+    const float display_height = static_cast<float>(display_mode->h);
 #endif
+    const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 
     ImGuiStyle& style = ImGui::GetStyle();
 

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -203,21 +203,6 @@ bool should_main_menu_bar_and_cursor_be_visible(
 
 void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 {
-    constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
-
-#ifdef __EMSCRIPTEN__
-    const double browser_window_height = EM_ASM_DOUBLE(
-    {
-        return window.outerHeight || window.screen.height;
-    });
-
-    if (browser_window_height <= 0.0)
-    {
-        return;
-    }
-
-    const float display_height = static_cast<float>(browser_window_height);
-#else
     SDL_DisplayID display_id = SDL_GetDisplayForWindow(sdl_window);
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(display_id);
 
@@ -225,8 +210,13 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     {
         return;
     }
+    constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
 
-    const float display_height = static_cast<float>(display_mode->h);
+    const float display_height = 
+#ifdef __EMSCRIPTEN__
+        static_cast<float>(EM_ASM_DOUBLE({ return screen.height; }));
+#else
+        static_cast<float>(display_mode->h);
 #endif
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -209,7 +209,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 #ifdef __EMSCRIPTEN__
     const double browser_window_height = EM_ASM_DOUBLE(
     {
-        return window.innerHeight || 0;
+        return window.innerHeight * (window.devicePixelRatio || 1);
     });
 
     if (browser_window_height <= 0.0)
@@ -252,7 +252,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
         previous_logged_window_width = window_width;
         previous_logged_window_height = window_height;
 
-        std::cout << "[web_scale] viewport_height=" << browser_window_height
+        std::cout << "[web_scale] viewport_pixel_height=" << browser_window_height
                   << " inner_height=" << browser_inner_height
                   << " device_pixel_ratio=" << browser_device_pixel_ratio
                   << " sdl_window_width=" << window_width

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -209,7 +209,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 #ifdef __EMSCRIPTEN__
     const double browser_window_height = EM_ASM_DOUBLE(
     {
-        return window.innerHeight * (window.devicePixelRatio || 1);
+        return window.outerHeight || window.screen.height;
     });
 
     if (browser_window_height <= 0.0)
@@ -252,7 +252,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
         previous_logged_window_width = window_width;
         previous_logged_window_height = window_height;
 
-        std::cout << "[web_scale] viewport_pixel_height=" << browser_window_height
+        std::cout << "[web_scale] outer_height=" << browser_window_height
                   << " inner_height=" << browser_inner_height
                   << " device_pixel_ratio=" << browser_device_pixel_ratio
                   << " sdl_window_width=" << window_width

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -1,11 +1,47 @@
+#include <algorithm>
 #include <backends/imgui_impl_sdlrenderer3.h>
+#include <cmath>
 #include <iostream>
 
+#include "carlito_embedded.h"
 #include "display_utilities.h"
 #include "imgui_rendering.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+
+constexpr float BASE_IMGUI_FONT_SIZE_PIXELS = 20.0f;
+
+static void refresh_web_imgui_font_if_needed(const float font_scale)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    const float target_font_size = std::max(1.0f, std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale));
+    static float previous_loaded_font_size = 0.0f;
+
+    if (io.FontDefault != nullptr && previous_loaded_font_size == target_font_size)
+    {
+        return;
+    }
+
+    previous_loaded_font_size = target_font_size;
+
+    ImFontConfig font_config;
+    font_config.FontDataOwnedByAtlas = false;
+
+    io.Fonts->Clear();
+    io.FontDefault = io.Fonts->AddFontFromMemoryTTF(
+        const_cast<unsigned char*>(carlito_ttf),
+        carlito_ttf_len,
+        target_font_size,
+        &font_config);
+    io.Fonts->Build();
+
+    ImGui_ImplSDLRenderer3_DestroyFontsTexture();
+    ImGui_ImplSDLRenderer3_CreateFontsTexture();
+
+    std::cout << "[web_font] target_font_size=" << target_font_size
+              << " font_scale=" << font_scale << "\n";
+}
 #endif
 
 #ifndef __EMSCRIPTEN__
@@ -237,6 +273,8 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 
 #ifdef __EMSCRIPTEN__
+    refresh_web_imgui_font_if_needed(font_scale);
+
     static float previous_logged_display_height = -1.0f;
     static float previous_logged_font_scale = -1.0f;
     static int previous_logged_window_width = -1;
@@ -277,7 +315,11 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     style.ItemSpacing = ImVec2(BASE_ITEM_SPACING_X * font_scale, BASE_ITEM_SPACING_Y * font_scale);
     style.ItemInnerSpacing = ImVec2(BASE_ITEM_INNER_SPACING_X * font_scale, BASE_ITEM_INNER_SPACING_Y * font_scale);
     style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
+#ifdef __EMSCRIPTEN__
+    style.FontScaleMain = 1.0f;
+#else
     style.FontScaleMain = font_scale;
+#endif
 }
 
 void render_frame(RenderContext& context)

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -209,7 +209,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 #ifdef __EMSCRIPTEN__
     const double browser_window_height = EM_ASM_DOUBLE(
     {
-        return window.innerHeight * (window.devicePixelRatio || 1);
+        return window.innerHeight || 0;
     });
 
     if (browser_window_height <= 0.0)
@@ -252,7 +252,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
         previous_logged_window_width = window_width;
         previous_logged_window_height = window_height;
 
-        std::cout << "[web_scale] viewport_pixel_height=" << browser_window_height
+        std::cout << "[web_scale] viewport_height=" << browser_window_height
                   << " inner_height=" << browser_inner_height
                   << " device_pixel_ratio=" << browser_device_pixel_ratio
                   << " sdl_window_width=" << window_width

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -12,14 +12,10 @@
 
 constexpr float BASE_IMGUI_FONT_SIZE_PIXELS = 20.0f;
 
-static void refresh_web_imgui_font_if_needed(
-    const float font_scale,
-    const float device_pixel_ratio)
+static void refresh_web_imgui_font_if_needed(const float font_scale)
 {
     ImGuiIO& io = ImGui::GetIO();
-    const float target_font_size = std::max(
-        1.0f,
-        std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale * device_pixel_ratio));
+    const float target_font_size = std::max(1.0f, std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale));
     static float previous_loaded_font_size = 0.0f;
 
     if (io.FontDefault != nullptr && previous_loaded_font_size == target_font_size)
@@ -44,8 +40,7 @@ static void refresh_web_imgui_font_if_needed(
     ImGui_ImplSDLRenderer3_CreateDeviceObjects();
 
     std::cout << "[web_font] target_font_size=" << target_font_size
-              << " font_scale=" << font_scale
-              << " device_pixel_ratio=" << device_pixel_ratio << "\n";
+              << " font_scale=" << font_scale << "\n";
 }
 #endif
 
@@ -278,7 +273,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 
 #ifdef __EMSCRIPTEN__
-    refresh_web_imgui_font_if_needed(font_scale, static_cast<float>(browser_device_pixel_ratio));
+    refresh_web_imgui_font_if_needed(font_scale);
 
     static float previous_logged_display_height = -1.0f;
     static float previous_logged_font_scale = -1.0f;
@@ -321,7 +316,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     style.ItemInnerSpacing = ImVec2(BASE_ITEM_INNER_SPACING_X * font_scale, BASE_ITEM_INNER_SPACING_Y * font_scale);
     style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
 #ifdef __EMSCRIPTEN__
-    style.FontScaleMain = 1.0f / static_cast<float>(browser_device_pixel_ratio);
+    style.FontScaleMain = 1.0f;
 #else
     style.FontScaleMain = font_scale;
 #endif

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -203,6 +203,21 @@ bool should_main_menu_bar_and_cursor_be_visible(
 
 void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 {
+    constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
+
+#ifdef __EMSCRIPTEN__
+    const double browser_window_height = EM_ASM_DOUBLE(
+    {
+        return window.outerHeight || window.screen.height;
+    });
+
+    if (browser_window_height <= 0.0)
+    {
+        return;
+    }
+
+    const float display_height = static_cast<float>(browser_window_height);
+#else
     SDL_DisplayID display_id = SDL_GetDisplayForWindow(sdl_window);
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(display_id);
 
@@ -210,13 +225,8 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     {
         return;
     }
-    constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
 
-    const float display_height = 
-#ifdef __EMSCRIPTEN__
-        static_cast<float>(EM_ASM_DOUBLE({ return screen.height; }));
-#else
-        static_cast<float>(display_mode->h);
+    const float display_height = static_cast<float>(display_mode->h);
 #endif
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
 

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -165,58 +165,6 @@ void render_frame(RenderContext& context)
         return;
     }
 
-#ifdef __EMSCRIPTEN__
-    {
-        ImGuiIO& io = ImGui::GetIO();
-        const double device_pixel_ratio = EM_ASM_DOUBLE({ return window.devicePixelRatio; });
-        const int canvas_width = EM_ASM_INT({ return document.getElementById('canvas').width; });
-        const int canvas_height = EM_ASM_INT({ return document.getElementById('canvas').height; });
-        const int canvas_css_width = EM_ASM_INT({ return Math.round(document.getElementById('canvas').getBoundingClientRect().width); });
-        const int canvas_css_height = EM_ASM_INT({ return Math.round(document.getElementById('canvas').getBoundingClientRect().height); });
-
-        static int previous_window_width = -1;
-        static int previous_window_height = -1;
-        static int previous_canvas_width = -1;
-        static int previous_canvas_height = -1;
-        static int previous_canvas_css_width = -1;
-        static int previous_canvas_css_height = -1;
-        static float previous_imgui_display_width = -1.0f;
-        static float previous_imgui_display_height = -1.0f;
-        static float previous_font_scale = -1.0f;
-
-        if (window_width != previous_window_width ||
-            window_height != previous_window_height ||
-            canvas_width != previous_canvas_width ||
-            canvas_height != previous_canvas_height ||
-            canvas_css_width != previous_canvas_css_width ||
-            canvas_css_height != previous_canvas_css_height ||
-            io.DisplaySize.x != previous_imgui_display_width ||
-            io.DisplaySize.y != previous_imgui_display_height ||
-            ImGui::GetStyle().FontScaleMain != previous_font_scale)
-        {
-            std::cout
-                << "[web-render] sdl=" << window_width << "x" << window_height
-                << " canvas=" << canvas_width << "x" << canvas_height
-                << " css=" << canvas_css_width << "x" << canvas_css_height
-                << " dpr=" << device_pixel_ratio
-                << " imgui_display=" << io.DisplaySize.x << "x" << io.DisplaySize.y
-                << " framebuffer_scale=" << io.DisplayFramebufferScale.x << "x" << io.DisplayFramebufferScale.y
-                << " font_scale=" << ImGui::GetStyle().FontScaleMain
-                << "\n";
-
-            previous_window_width = window_width;
-            previous_window_height = window_height;
-            previous_canvas_width = canvas_width;
-            previous_canvas_height = canvas_height;
-            previous_canvas_css_width = canvas_css_width;
-            previous_canvas_css_height = canvas_css_height;
-            previous_imgui_display_width = io.DisplaySize.x;
-            previous_imgui_display_height = io.DisplaySize.y;
-            previous_font_scale = ImGui::GetStyle().FontScaleMain;
-        }
-    }
-#endif
-
     context.is_currently_rendering = true;
     const uint8_t currently_published_frame_buffer_index = context.game_boy_emulator->get_published_frame_buffer_index_thread_safe();
 
@@ -237,25 +185,6 @@ void render_frame(RenderContext& context)
     }
 
     SDL_RenderClear(context.sdl_renderer);
-#ifdef __EMSCRIPTEN__
-    const float main_menu_bar_height_pixels = ImGui::GetFrameHeight();
-    const float available_height = std::max(0.0f, static_cast<float>(window_height) - main_menu_bar_height_pixels);
-    const int emulation_scale = std::max(
-        1,
-        std::min(
-            window_width / static_cast<int>(DISPLAY_WIDTH_PIXELS),
-            static_cast<int>(available_height) / static_cast<int>(DISPLAY_HEIGHT_PIXELS)));
-    const float emulation_width = static_cast<float>(DISPLAY_WIDTH_PIXELS * emulation_scale);
-    const float emulation_height = static_cast<float>(DISPLAY_HEIGHT_PIXELS * emulation_scale);
-    SDL_FRect emulation_screen_rectangle =
-        SDL_FRect
-        {
-            (static_cast<float>(window_width) - emulation_width) * 0.5f,
-            main_menu_bar_height_pixels + (available_height - emulation_height) * 0.5f,
-            emulation_width,
-            emulation_height
-        };
-#else
     SDL_FRect emulation_screen_rectangle =
         SDL_FRect
         {
@@ -264,7 +193,6 @@ void render_frame(RenderContext& context)
             static_cast<float>(DISPLAY_WIDTH_PIXELS),
             static_cast<float>(DISPLAY_HEIGHT_PIXELS)
         };
-#endif
     SDL_RenderTexture(context.sdl_renderer, context.sdl_texture, nullptr, &emulation_screen_rectangle);
 
     sdl_logical_presentation_imgui_workaround_t logical_values

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -1,6 +1,5 @@
+#include <cstdint>
 #include <backends/imgui_impl_sdlrenderer3.h>
-
-#include <cmath>
 
 #include "display_utilities.h"
 #include "imgui_rendering.h"
@@ -214,10 +213,12 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 
 #ifdef __EMSCRIPTEN__
     const float display_height = static_cast<float>(std::max(1, get_web_viewport_metrics().pixel_viewport_height));
+    constexpr float WEB_FONT_SCALE_MULTIPLIER = 1.15f;
+    const float font_scale = (display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING) * WEB_FONT_SCALE_MULTIPLIER;
 #else
     const float display_height = static_cast<float>(display_mode->h);
-#endif
     const float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
+#endif
 
     ImGuiStyle& style = ImGui::GetStyle();
 

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -145,9 +145,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     }
 }
 
-void render_frame(
-    RenderContext& context,
-    bool should_skip_frame_data_update)
+void render_frame(RenderContext& context)
 {
     if (context.is_currently_rendering)
     {
@@ -163,8 +161,7 @@ void render_frame(
     context.is_currently_rendering = true;
     const uint8_t currently_published_frame_buffer_index = context.game_boy_emulator->get_published_frame_buffer_index_thread_safe();
 
-    if (currently_published_frame_buffer_index != *context.previously_published_frame_buffer_index &&
-        !should_skip_frame_data_update)
+    if (currently_published_frame_buffer_index != *context.previously_published_frame_buffer_index)
     {
         auto const& pixel_frame_buffer = context.game_boy_emulator->get_pixel_frame_buffer(currently_published_frame_buffer_index);
 

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -10,11 +10,13 @@
 int get_initial_window_scale_for_display()
 {
 #ifdef __EMSCRIPTEN__
-    const int viewport_width = EM_ASM_INT({ return window.innerWidth; });
-    const int viewport_height = EM_ASM_INT({ return window.innerHeight; });
+    double dpr = emscripten_get_device_pixel_ratio();
+    int viewport_width = EM_ASM_INT({ return window.innerWidth; });
+    int viewport_height = EM_ASM_INT({ return window.innerHeight; });
+    // Scale to physical pixels so canvas buffer matches display resolution
     return std::max(1, std::min(
-        viewport_width / DISPLAY_WIDTH_PIXELS,
-        viewport_height / DISPLAY_HEIGHT_PIXELS));
+        static_cast<int>(viewport_width * dpr) / DISPLAY_WIDTH_PIXELS,
+        static_cast<int>(viewport_height * dpr) / DISPLAY_HEIGHT_PIXELS));
 #else
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
     if (display_mode != nullptr)
@@ -119,30 +121,36 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     SDL_DisplayID display_id = SDL_GetDisplayForWindow(sdl_window);
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(display_id);
 
-    if (display_mode != nullptr)
+    if (display_mode == nullptr)
     {
-        constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
-
-        const float display_height = static_cast<float>(display_mode->h);
-        float font_scale = (display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING);
-
-        ImGuiStyle& style = ImGui::GetStyle();
-
-        constexpr float BASE_FRAME_PADDING_X = 6.0f;
-        constexpr float BASE_FRAME_PADDING_Y = 6.0f;
-        constexpr float BASE_ITEM_SPACING_X = 8.0f;
-        constexpr float BASE_ITEM_SPACING_Y = 4.0f;
-        constexpr float BASE_ITEM_INNER_SPACING_X = 4.0f;
-        constexpr float BASE_ITEM_INNER_SPACING_Y = 6.0f;
-        constexpr float BASE_WINDOW_PADDING_X = 8.0f;
-        constexpr float BASE_WINDOW_PADDING_Y = 10.0f;
-
-        style.FramePadding = ImVec2(BASE_FRAME_PADDING_X * font_scale, BASE_FRAME_PADDING_Y * font_scale);
-        style.ItemSpacing = ImVec2(BASE_ITEM_SPACING_X * font_scale, BASE_ITEM_SPACING_Y * font_scale);
-        style.ItemInnerSpacing = ImVec2(BASE_ITEM_INNER_SPACING_X * font_scale, BASE_ITEM_INNER_SPACING_Y * font_scale);
-        style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
-        style.FontScaleMain = font_scale;
+        return;
     }
+
+#ifdef __EMSCRIPTEN__
+    float display_height = static_cast<float>(EM_ASM_INT({ return screen.height * window.devicePixelRatio; }));
+#else
+    float display_height = static_cast<float>(display_mode->h);
+#endif
+
+    constexpr float BASE_PIXEL_HEIGHT_FOR_FONT_SCALING = 1440.0f;
+    float font_scale = display_height / BASE_PIXEL_HEIGHT_FOR_FONT_SCALING;
+
+    ImGuiStyle& style = ImGui::GetStyle();
+
+    constexpr float BASE_FRAME_PADDING_X = 6.0f;
+    constexpr float BASE_FRAME_PADDING_Y = 6.0f;
+    constexpr float BASE_ITEM_SPACING_X = 8.0f;
+    constexpr float BASE_ITEM_SPACING_Y = 4.0f;
+    constexpr float BASE_ITEM_INNER_SPACING_X = 4.0f;
+    constexpr float BASE_ITEM_INNER_SPACING_Y = 6.0f;
+    constexpr float BASE_WINDOW_PADDING_X = 8.0f;
+    constexpr float BASE_WINDOW_PADDING_Y = 10.0f;
+
+    style.FramePadding = ImVec2(BASE_FRAME_PADDING_X * font_scale, BASE_FRAME_PADDING_Y * font_scale);
+    style.ItemSpacing = ImVec2(BASE_ITEM_SPACING_X * font_scale, BASE_ITEM_SPACING_Y * font_scale);
+    style.ItemInnerSpacing = ImVec2(BASE_ITEM_INNER_SPACING_X * font_scale, BASE_ITEM_INNER_SPACING_Y * font_scale);
+    style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
+    style.FontScaleMain = font_scale;
 }
 
 void render_frame(RenderContext& context)

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -20,19 +20,14 @@ static void refresh_web_imgui_font_if_needed(
     const float target_font_size = std::max(
         1.0f,
         std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale * device_pixel_ratio));
-    const float font_size_ratio = BASE_IMGUI_FONT_SIZE_PIXELS * font_scale / target_font_size;
     static float previous_loaded_font_size = 0.0f;
-    static float previous_font_size_ratio = 0.0f;
 
-    if (io.FontDefault != nullptr &&
-        previous_loaded_font_size == target_font_size &&
-        previous_font_size_ratio == font_size_ratio)
+    if (io.FontDefault != nullptr && previous_loaded_font_size == target_font_size)
     {
         return;
     }
 
     previous_loaded_font_size = target_font_size;
-    previous_font_size_ratio = font_size_ratio;
 
     ImFontConfig font_config;
     font_config.FontDataOwnedByAtlas = false;
@@ -50,7 +45,6 @@ static void refresh_web_imgui_font_if_needed(
 
     std::cout << "[web_font] target_font_size=" << target_font_size
               << " font_scale=" << font_scale
-              << " font_size_ratio=" << font_size_ratio
               << " device_pixel_ratio=" << device_pixel_ratio << "\n";
 }
 #endif
@@ -269,10 +263,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     const double browser_device_pixel_ratio = EM_ASM_DOUBLE({ return window.devicePixelRatio || 1; });
     int window_width = 0;
     int window_height = 0;
-    int window_pixel_width = 0;
-    int window_pixel_height = 0;
     SDL_GetWindowSize(sdl_window, &window_width, &window_height);
-    SDL_GetWindowSizeInPixels(sdl_window, &window_pixel_width, &window_pixel_height);
 #else
     SDL_DisplayID display_id = SDL_GetDisplayForWindow(sdl_window);
     const SDL_DisplayMode* display_mode = SDL_GetCurrentDisplayMode(display_id);
@@ -289,43 +280,28 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
 #ifdef __EMSCRIPTEN__
     refresh_web_imgui_font_if_needed(font_scale, static_cast<float>(browser_device_pixel_ratio));
 
-    const float loaded_font_size = std::max(1.0f, std::round(BASE_IMGUI_FONT_SIZE_PIXELS * font_scale * static_cast<float>(browser_device_pixel_ratio)));
-    const float font_scale_main = (BASE_IMGUI_FONT_SIZE_PIXELS * font_scale) / loaded_font_size;
-
     static float previous_logged_display_height = -1.0f;
     static float previous_logged_font_scale = -1.0f;
     static int previous_logged_window_width = -1;
     static int previous_logged_window_height = -1;
-    static int previous_logged_window_pixel_width = -1;
-    static int previous_logged_window_pixel_height = -1;
-    static float previous_logged_font_scale_main = -1.0f;
 
     if (previous_logged_display_height != display_height ||
         previous_logged_font_scale != font_scale ||
         previous_logged_window_width != window_width ||
-        previous_logged_window_height != window_height ||
-        previous_logged_window_pixel_width != window_pixel_width ||
-        previous_logged_window_pixel_height != window_pixel_height ||
-        previous_logged_font_scale_main != font_scale_main)
+        previous_logged_window_height != window_height)
     {
         previous_logged_display_height = display_height;
         previous_logged_font_scale = font_scale;
         previous_logged_window_width = window_width;
         previous_logged_window_height = window_height;
-        previous_logged_window_pixel_width = window_pixel_width;
-        previous_logged_window_pixel_height = window_pixel_height;
-        previous_logged_font_scale_main = font_scale_main;
 
         std::cout << "[web_scale] viewport_height=" << browser_window_height
                   << " inner_height=" << browser_inner_height
                   << " device_pixel_ratio=" << browser_device_pixel_ratio
                   << " sdl_window_width=" << window_width
                   << " sdl_window_height=" << window_height
-                  << " sdl_window_pixel_width=" << window_pixel_width
-                  << " sdl_window_pixel_height=" << window_pixel_height
                   << " display_height=" << display_height
-                  << " font_scale=" << font_scale
-                  << " font_scale_main=" << font_scale_main << "\n";
+                  << " font_scale=" << font_scale << "\n";
     }
 #endif
 
@@ -345,7 +321,7 @@ void update_imgui_scale_by_resolution(SDL_Window* sdl_window)
     style.ItemInnerSpacing = ImVec2(BASE_ITEM_INNER_SPACING_X * font_scale, BASE_ITEM_INNER_SPACING_Y * font_scale);
     style.WindowPadding = ImVec2(BASE_WINDOW_PADDING_X * font_scale, BASE_WINDOW_PADDING_Y * font_scale);
 #ifdef __EMSCRIPTEN__
-    style.FontScaleMain = font_scale_main;
+    style.FontScaleMain = 1.0f / static_cast<float>(browser_device_pixel_ratio);
 #else
     style.FontScaleMain = font_scale;
 #endif

--- a/gui/src/display_utilities.cpp
+++ b/gui/src/display_utilities.cpp
@@ -69,7 +69,7 @@ static bool is_cursor_currently_visible()
 #ifdef __EMSCRIPTEN__
     return EM_ASM_INT(
     {
-        return Module.isWebCursorVisible ? 1 : 0;
+        return Module.is_web_cursor_visible ? 1 : 0;
     }) != 0;
 #else
     return SDL_CursorVisible();

--- a/gui/src/imgui_rendering.cpp
+++ b/gui/src/imgui_rendering.cpp
@@ -8,6 +8,9 @@ void render_main_menu_bar(
     EmulationController& emulation_controller,
     FileLoadingStatus& file_loading_status,
     MenuAndCursorDisplayStatus& menu_and_cursor_display_status,
+#ifndef __EMSCRIPTEN__
+    FrameDiagnosticsState& frame_diagnostics_state,
+#endif
     GraphicsController& graphics_controller,
     MenuProperties& menu_properties,
     const KeyBindings& key_bindings,
@@ -202,6 +205,14 @@ void render_main_menu_bar(
             }
             ImGui::EndMenu();
         }
+#ifndef __EMSCRIPTEN__
+        if (ImGui::BeginMenu("Debug"))
+        {
+            ImGui::Spacing();
+            ImGui::MenuItem("Show Performance Overlay", nullptr, &frame_diagnostics_state.is_overlay_enabled);
+            ImGui::EndMenu();
+        }
+#endif
         if (game_boy_emulator.is_game_rom_loaded_in_memory_thread_safe())
         {
             if (is_emulation_paused)

--- a/gui/src/imgui_rendering.cpp
+++ b/gui/src/imgui_rendering.cpp
@@ -174,7 +174,7 @@ void render_main_menu_bar(
             {
                 game_boy_emulator.try_save_save_file(std::filesystem::path(SDL_GetBasePath()));
                 set_emulation_screen_blank(graphics_controller);
-                SDL_SetWindowTitle(sdl_window, std::string("Emulate Game Boy").c_str());
+                SDL_SetWindowTitle(sdl_window, std::string("Game Boy Emulator").c_str());
                 game_boy_emulator.unload_game_rom_from_memory_thread_safe();
                 *loaded_game_rom_path = "";
                 game_boy_emulator.reset_state();

--- a/gui/src/imgui_rendering.cpp
+++ b/gui/src/imgui_rendering.cpp
@@ -10,7 +10,7 @@ void render_main_menu_bar(
     MenuAndCursorDisplayStatus& menu_and_cursor_display_status,
     GraphicsController& graphics_controller,
     MenuProperties& menu_properties,
-    KeyBindings& key_bindings,
+    const KeyBindings& key_bindings,
     SDL_Window* sdl_window,
     std::string* loaded_game_rom_path,
     std::string* loaded_boot_rom_path,
@@ -87,11 +87,13 @@ void render_main_menu_bar(
                 }
                 emulation_controller.is_emulation_paused_atomic.store(is_emulation_paused);
             }
+#ifndef __EMSCRIPTEN__
             imgui_spaced_separator();
             if (ImGui::MenuItem("Quit", "[Alt+F4]"))
             {
                 should_stop_emulation = true;
             }
+#endif
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Video"))
@@ -129,9 +131,14 @@ void render_main_menu_bar(
                 menu_properties.is_custom_palette_editor_open = true;
             }
             imgui_spaced_separator();
+            const std::string fullscreen_shortcut_label = get_keybind_label(key_bindings.fullscreen);
+            const char* fullscreen_shortcut = fullscreen_shortcut_label.c_str();
+#ifdef __EMSCRIPTEN__
+            fullscreen_shortcut = nullptr;
+#endif
             if (ImGui::MenuItem(
                     is_fullscreen_enabled ? "Exit Fullscreen" : "Fullscreen",
-                    get_keybind_label(key_bindings.fullscreen).c_str()))
+                    fullscreen_shortcut))
             {
                 toggle_fullscreen_enabled_state(
                     menu_and_cursor_display_status,
@@ -378,7 +385,12 @@ void render_keybinds_editor(
                 &key_bindings.fullscreen
             };
 
-            for (int i = 0; i < 5; i++)
+            int emulator_key_count = static_cast<int>(std::size(emulator_labels));
+#ifdef __EMSCRIPTEN__
+            emulator_key_count--;
+#endif
+
+            for (int i = 0; i < emulator_key_count; i++)
             {
                 ImGui::Text("%s:", emulator_labels[i]);
                 ImGui::SameLine(emulator_label_width);
@@ -463,7 +475,7 @@ void render_error_message_popup(
     }
 }
 
-std::string get_keybind_label(SDL_Keycode key)
+std::string get_keybind_label(const SDL_Keycode key)
 {
     if (key == SDLK_UNKNOWN)
     {
@@ -472,7 +484,7 @@ std::string get_keybind_label(SDL_Keycode key)
     return std::string("[") + SDL_GetKeyName(key) + "]";
 }
 
-ImVec4 get_imvec4_from_abgr(uint32_t abgr)
+ImVec4 get_imvec4_from_abgr(const uint32_t abgr)
 {
     const uint8_t alpha = (abgr >> 24) & 0xFF;
     const uint8_t blue = (abgr >> 16) & 0xFF;

--- a/gui/src/imgui_rendering.cpp
+++ b/gui/src/imgui_rendering.cpp
@@ -135,13 +135,9 @@ void render_main_menu_bar(
             }
             imgui_spaced_separator();
             const std::string fullscreen_shortcut_label = get_keybind_label(key_bindings.fullscreen);
-            const char* fullscreen_shortcut = fullscreen_shortcut_label.c_str();
-#ifdef __EMSCRIPTEN__
-            fullscreen_shortcut = nullptr;
-#endif
             if (ImGui::MenuItem(
                     is_fullscreen_enabled ? "Exit Fullscreen" : "Fullscreen",
-                    fullscreen_shortcut))
+                    fullscreen_shortcut_label.c_str()))
             {
                 toggle_fullscreen_enabled_state(
                     menu_and_cursor_display_status,
@@ -397,9 +393,6 @@ void render_keybinds_editor(
             };
 
             int emulator_key_count = static_cast<int>(std::size(emulator_labels));
-#ifdef __EMSCRIPTEN__
-            emulator_key_count--;
-#endif
 
             for (int i = 0; i < emulator_key_count; i++)
             {

--- a/gui/src/imgui_rendering.cpp
+++ b/gui/src/imgui_rendering.cpp
@@ -2,6 +2,115 @@
 #include "imgui_rendering.h"
 #include "input_events.h"
 
+#ifndef __EMSCRIPTEN__
+void render_frame_diagnostics_overlay(FrameDiagnosticsState& frame_diagnostics_state)
+{
+    if (!frame_diagnostics_state.is_overlay_enabled)
+    {
+        return;
+    }
+
+    ImGui::SetNextWindowBgAlpha(0.75f);
+    ImGui::SetNextWindowPos(ImVec2(12.0f, 36.0f), ImGuiCond_FirstUseEver);
+
+    if (ImGui::Begin(
+            "Recent Performance",
+            &frame_diagnostics_state.is_overlay_enabled,
+            ImGuiWindowFlags_AlwaysAutoResize |
+            ImGuiWindowFlags_NoSavedSettings |
+            ImGuiWindowFlags_NoFocusOnAppearing))
+    {
+        constexpr float COLUMN_SPACING_WIDTH = 12.0f;
+        constexpr float VALUE_COLUMN_WIDTH = 160.0f;
+        const double displayed_emulator_frame_rate =
+            !frame_diagnostics_state.has_completed_sample &&
+            frame_diagnostics_state.sample_frame_count > 0 &&
+            frame_diagnostics_state.sample_elapsed_seconds > 0.0
+                ? static_cast<double>(frame_diagnostics_state.sample_emulator_frame_count) / frame_diagnostics_state.sample_elapsed_seconds
+                : frame_diagnostics_state.displayed_emulator_frame_rate;
+        const double displayed_worst_frame_time_ms =
+            !frame_diagnostics_state.has_completed_sample && frame_diagnostics_state.sample_frame_count > 0
+                ? frame_diagnostics_state.sample_worst_frame_time_ms
+                : frame_diagnostics_state.displayed_worst_frame_time_ms;
+        const uint32_t displayed_skipped_frame_count =
+            !frame_diagnostics_state.has_completed_sample && frame_diagnostics_state.sample_frame_count > 0
+                ? frame_diagnostics_state.sample_skipped_frame_count
+                : frame_diagnostics_state.displayed_skipped_frame_count;
+
+        if (ImGui::BeginTable(
+                "performance_overlay_table",
+                3,
+                ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoSavedSettings))
+        {
+            ImGui::TableSetupColumn("Metric");
+            ImGui::TableSetupColumn("Spacing", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, COLUMN_SPACING_WIDTH);
+            ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed, VALUE_COLUMN_WIDTH);
+
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted("Emulation FPS:");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TableSetColumnIndex(2);
+            const std::string emulation_fps_text = std::format("{:.2f}", displayed_emulator_frame_rate);
+            ImGui::TextUnformatted(emulation_fps_text.c_str());
+
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted("Worst Frame Time:");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TableSetColumnIndex(2);
+            const std::string worst_frame_time_text = std::format("{:.2f} ms", displayed_worst_frame_time_ms);
+            ImGui::TextUnformatted(worst_frame_time_text.c_str());
+
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted("Skipped Frames:");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TableSetColumnIndex(2);
+            const std::string skipped_frames_text = std::format("{}", displayed_skipped_frame_count);
+            ImGui::TextUnformatted(skipped_frames_text.c_str());
+
+            ImGui::EndTable();
+        }
+    }
+    ImGui::End();
+}
+#endif
+
+void render_auxiliary_windows(
+    const uint8_t currently_published_frame_buffer_index,
+    GameBoyEmulator::Emulator& game_boy_emulator,
+    FileLoadingStatus& file_loading_status,
+    std::atomic<bool>& is_emulation_paused_atomic,
+    GraphicsController& graphics_controller,
+    MenuProperties& menu_properties,
+    KeyBindings& key_bindings,
+    std::string& error_message
+#ifndef __EMSCRIPTEN__
+    , FrameDiagnosticsState& frame_diagnostics_state
+#endif
+)
+{
+    render_custom_colour_palette_editor(
+        currently_published_frame_buffer_index,
+        game_boy_emulator,
+        menu_properties,
+        graphics_controller);
+
+    render_keybinds_editor(
+        menu_properties,
+        key_bindings);
+
+    render_error_message_popup(
+        file_loading_status,
+        is_emulation_paused_atomic,
+        error_message);
+
+#ifndef __EMSCRIPTEN__
+    render_frame_diagnostics_overlay(frame_diagnostics_state);
+#endif
+}
+
 void render_main_menu_bar(
     const uint8_t currently_published_frame_buffer_index,
     GameBoyEmulator::Emulator& game_boy_emulator,

--- a/gui/src/input_events.cpp
+++ b/gui/src/input_events.cpp
@@ -2,10 +2,117 @@
 #include "input_events.h"
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-#endif
-#ifndef __EMSCRIPTEN__
+#else
 #include "nfd_sdl3.h"
 #endif
+
+#ifdef __EMSCRIPTEN__
+namespace
+{
+
+enum class WebFileSelectionResult
+{
+    None,
+    Waiting,
+    Ready,
+    Cancelled,
+    Error
+};
+
+struct WebPendingFileSelection
+{
+    std::atomic<WebFileSelectionResult> result{WebFileSelectionResult::None};
+    std::atomic<GameBoyEmulator::FileType> file_type{GameBoyEmulator::FileType::GameROM};
+};
+
+WebPendingFileSelection web_pending_file_selection{};
+
+constexpr const char* WEB_SELECTED_GAME_ROM_PATH = "/tmp/web-selected-game-rom.gb";
+constexpr const char* WEB_SELECTED_BOOT_ROM_PATH = "/tmp/web-selected-boot-rom.bin";
+
+const char* get_web_selected_rom_path(const GameBoyEmulator::FileType file_type)
+{
+    return file_type == GameBoyEmulator::FileType::BootROM
+        ? WEB_SELECTED_BOOT_ROM_PATH
+        : WEB_SELECTED_GAME_ROM_PATH;
+}
+
+} // namespace
+
+extern "C"
+{
+
+EMSCRIPTEN_KEEPALIVE void set_pending_web_file_selection_result(const int file_type, const int result)
+{
+    web_pending_file_selection.file_type.store(static_cast<GameBoyEmulator::FileType>(file_type), std::memory_order_release);
+    web_pending_file_selection.result.store(static_cast<WebFileSelectionResult>(result), std::memory_order_release);
+}
+
+}
+
+#endif
+
+static void finish_failed_rom_loading_operation(
+    EmulationController& emulation_controller,
+    FileLoadingStatus& file_loading_status,
+    const std::string& error_message)
+{
+    file_loading_status.did_rom_loading_error_occur = !error_message.empty();
+    emulation_controller.is_emulation_paused_atomic.store(
+        file_loading_status.is_emulation_paused_before_rom_loading,
+        std::memory_order_release);
+}
+
+static bool try_load_file_to_memory_from_path(
+    const std::filesystem::path& file_path,
+    GameBoyEmulator::FileType file_type,
+    GameBoyEmulator::Emulator& game_boy_emulator,
+    EmulationController& emulation_controller,
+    FileLoadingStatus& file_loading_status,
+    MenuAndCursorDisplayStatus& menu_and_cursor_display_status,
+    SDL_Window* sdl_window,
+    std::string* loaded_rom_path,
+    std::string& error_message)
+{
+    bool is_operation_successful = false;
+
+    if (file_type == GameBoyEmulator::FileType::GameROM)
+    {
+        game_boy_emulator.try_save_save_file(std::filesystem::path(SDL_GetBasePath()));
+    }
+
+    if (game_boy_emulator.try_to_load_file_to_memory(file_path, file_type, error_message))
+    {
+        if (file_type == GameBoyEmulator::FileType::GameROM)
+        {
+            game_boy_emulator.reset_state();
+            game_boy_emulator.try_load_save_file(std::filesystem::path(SDL_GetBasePath()));
+        }
+        *loaded_rom_path = file_path.string();
+        is_operation_successful = true;
+    }
+
+    if (is_operation_successful)
+    {
+        file_loading_status.did_rom_loading_error_occur = false;
+        if (file_type == GameBoyEmulator::FileType::GameROM)
+        {
+            SDL_SetWindowTitle(
+                sdl_window,
+                std::string("Emulate Game Boy - " + game_boy_emulator.get_loaded_game_rom_title_thread_safe()).c_str());
+        }
+        emulation_controller.is_emulation_paused_atomic.store(false, std::memory_order_release);
+        menu_and_cursor_display_status.cursor_changes_to_ignore_count =
+            menu_and_cursor_display_status.MAX_CURSOR_CHANGES_TO_IGNORE;
+        menu_and_cursor_display_status.seconds_until_main_menu_bar_and_cursor_hidden = 0.0f;
+    }
+    else
+    {
+        finish_failed_rom_loading_operation(emulation_controller, file_loading_status, error_message);
+    }
+
+    return is_operation_successful;
+}
 
 bool try_load_file_to_memory_with_dialog(
     GameBoyEmulator::FileType file_type,
@@ -17,13 +124,35 @@ bool try_load_file_to_memory_with_dialog(
     std::string* loaded_rom_path,
     std::string& error_message)
 {
+    error_message.clear();
+    file_loading_status.did_rom_loading_error_occur = false;
+    file_loading_status.is_emulation_paused_before_rom_loading =
+        emulation_controller.is_emulation_paused_atomic.exchange(true, std::memory_order_acq_rel);
+
 #ifdef __EMSCRIPTEN__
-    // File loading on web is handled via the HTML file input element in shell.html
+    web_pending_file_selection.file_type.store(file_type, std::memory_order_release);
+    web_pending_file_selection.result.store(WebFileSelectionResult::Waiting, std::memory_order_release);
+
+    const int did_open_picker = EM_ASM_INT(
+        {
+            if (Module.openRomFilePicker)
+            {
+                Module.openRomFilePicker($0);
+                return 1;
+            }
+            return 0;
+        },
+        static_cast<int>(file_type));
+
+    if (!did_open_picker)
+    {
+        web_pending_file_selection.result.store(WebFileSelectionResult::None, std::memory_order_release);
+        error_message = "Web file picker is unavailable.";
+        finish_failed_rom_loading_operation(emulation_controller, file_loading_status, error_message);
+    }
+
     return false;
 #else
-    file_loading_status.is_emulation_paused_before_rom_loading = emulation_controller.is_emulation_paused_atomic.load(std::memory_order_acquire);
-    emulation_controller.is_emulation_paused_atomic.store(true, std::memory_order_release);
-
     nfdopendialogu8args_t open_dialog_arguments{};
     nfdu8filteritem_t filters[] =
     {
@@ -40,21 +169,16 @@ bool try_load_file_to_memory_with_dialog(
 
     if (result == NFD_OKAY)
     {
-        if (file_type == GameBoyEmulator::FileType::GameROM)
-        {
-            game_boy_emulator.try_save_save_file(std::filesystem::path(SDL_GetBasePath()));
-        }
-
-        if (game_boy_emulator.try_to_load_file_to_memory(rom_path, file_type, error_message))
-        {
-            if (file_type == GameBoyEmulator::FileType::GameROM)
-            {
-                game_boy_emulator.reset_state();
-                game_boy_emulator.try_load_save_file(std::filesystem::path(SDL_GetBasePath()));
-            }
-            is_operation_successful = true;
-        }
-        *loaded_rom_path = rom_path;
+        is_operation_successful = try_load_file_to_memory_from_path(
+            rom_path,
+            file_type,
+            game_boy_emulator,
+            emulation_controller,
+            file_loading_status,
+            menu_and_cursor_display_status,
+            sdl_window,
+            loaded_rom_path,
+            error_message);
         NFD_FreePathU8(rom_path);
     }
     else if (result == NFD_ERROR)
@@ -63,29 +187,66 @@ bool try_load_file_to_memory_with_dialog(
         error_message = NFD_GetError();
     }
 
-    if (is_operation_successful)
+    if (result != NFD_OKAY)
     {
-        if (file_type == GameBoyEmulator::FileType::GameROM)
-        {
-            SDL_SetWindowTitle(
-                sdl_window,
-                std::string("Emulate Game Boy - " + game_boy_emulator.get_loaded_game_rom_title_thread_safe()).c_str());
-        }
-        emulation_controller.is_emulation_paused_atomic.store(false, std::memory_order_release);
-        menu_and_cursor_display_status.cursor_changes_to_ignore_count =
-            menu_and_cursor_display_status.MAX_CURSOR_CHANGES_TO_IGNORE;
-        menu_and_cursor_display_status.seconds_until_main_menu_bar_and_cursor_hidden = 0.0f;
-    }
-    else
-    {
-        file_loading_status.did_rom_loading_error_occur = (error_message != "");
-        emulation_controller.is_emulation_paused_atomic.store(
-            file_loading_status.is_emulation_paused_before_rom_loading,
-            std::memory_order_release);
+        finish_failed_rom_loading_operation(emulation_controller, file_loading_status, error_message);
     }
     return is_operation_successful;
 #endif
 }
+
+#ifdef __EMSCRIPTEN__
+void consume_pending_web_file_selection(
+    GameBoyEmulator::Emulator& game_boy_emulator,
+    EmulationController& emulation_controller,
+    FileLoadingStatus& file_loading_status,
+    MenuAndCursorDisplayStatus& menu_and_cursor_display_status,
+    SDL_Window* sdl_window,
+    std::string* loaded_game_rom_path,
+    std::string* loaded_boot_rom_path,
+    std::string& error_message)
+{
+    const WebFileSelectionResult result =
+        web_pending_file_selection.result.exchange(WebFileSelectionResult::None, std::memory_order_acq_rel);
+
+    if (result == WebFileSelectionResult::None || result == WebFileSelectionResult::Waiting)
+    {
+        if (result == WebFileSelectionResult::Waiting)
+        {
+            web_pending_file_selection.result.store(WebFileSelectionResult::Waiting, std::memory_order_release);
+        }
+        return;
+    }
+
+    const GameBoyEmulator::FileType file_type = web_pending_file_selection.file_type.load(std::memory_order_acquire);
+
+    if (result == WebFileSelectionResult::Cancelled)
+    {
+        emulation_controller.is_emulation_paused_atomic.store(
+            file_loading_status.is_emulation_paused_before_rom_loading,
+            std::memory_order_release);
+        return;
+    }
+
+    if (result == WebFileSelectionResult::Error)
+    {
+        error_message = "Failed to read the selected file in the browser.";
+        finish_failed_rom_loading_operation(emulation_controller, file_loading_status, error_message);
+        return;
+    }
+
+    try_load_file_to_memory_from_path(
+        get_web_selected_rom_path(file_type),
+        file_type,
+        game_boy_emulator,
+        emulation_controller,
+        file_loading_status,
+        menu_and_cursor_display_status,
+        sdl_window,
+        file_type == GameBoyEmulator::FileType::BootROM ? loaded_boot_rom_path : loaded_game_rom_path,
+        error_message);
+}
+#endif
 
 void toggle_emulation_paused_state(
     std::atomic<bool>& is_emulation_paused_atomic,

--- a/gui/src/input_events.cpp
+++ b/gui/src/input_events.cpp
@@ -363,6 +363,12 @@ void handle_sdl_events(
 
                 if (menu_properties.keybinds_editor_state.is_waiting_for_key && is_key_pressed)
                 {
+#ifdef __EMSCRIPTEN__
+                    if (key == SDLK_ESCAPE || key == SDLK_F11)
+                    {
+                        break;
+                    }
+#endif
                     SDL_Keycode* gameboy_keys[] =
                     {
                         &key_bindings.button_up,
@@ -397,13 +403,11 @@ void handle_sdl_events(
 
                 if (key == key_bindings.fullscreen)
                 {
-#ifndef __EMSCRIPTEN__
                     if (is_key_pressed && !key_pressed_states.was_fullscreen_key_previously_pressed)
                     {
                         toggle_fullscreen_enabled_state(menu_and_cursor_display_status, sdl_window);
                     }
                     key_pressed_states.was_fullscreen_key_previously_pressed = is_key_pressed;
-#endif
                 }
                 else if (key == key_bindings.load_game_rom && is_key_pressed)
                 {

--- a/gui/src/input_events.cpp
+++ b/gui/src/input_events.cpp
@@ -1,6 +1,8 @@
 #include "display_utilities.h"
 #include "input_events.h"
+#ifndef __EMSCRIPTEN__
 #include "nfd_sdl3.h"
+#endif
 
 bool try_load_file_to_memory_with_dialog(
     GameBoyEmulator::FileType file_type,
@@ -12,6 +14,10 @@ bool try_load_file_to_memory_with_dialog(
     std::string* loaded_rom_path,
     std::string& error_message)
 {
+#ifdef __EMSCRIPTEN__
+    // File loading on web is handled via the HTML file input element in shell.html
+    return false;
+#else
     file_loading_status.is_emulation_paused_before_rom_loading = emulation_controller.is_emulation_paused_atomic.load(std::memory_order_acquire);
     emulation_controller.is_emulation_paused_atomic.store(true, std::memory_order_release);
 
@@ -75,6 +81,7 @@ bool try_load_file_to_memory_with_dialog(
             std::memory_order_release);
     }
     return is_operation_successful;
+#endif
 }
 
 void toggle_emulation_paused_state(

--- a/gui/src/input_events.cpp
+++ b/gui/src/input_events.cpp
@@ -1,5 +1,8 @@
 #include "display_utilities.h"
 #include "input_events.h"
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 #ifndef __EMSCRIPTEN__
 #include "nfd_sdl3.h"
 #endif
@@ -106,13 +109,17 @@ void toggle_fullscreen_enabled_state(
     MenuAndCursorDisplayStatus& menu_and_cursor_display_status,
     SDL_Window* sdl_window)
 {
+#ifndef __EMSCRIPTEN__
     float mouse_x_monitor_coordinate, mouse_y_monitor_coordinate;
     SDL_GetGlobalMouseState(&mouse_x_monitor_coordinate, &mouse_y_monitor_coordinate);
+#endif
 
     const bool was_fullscreen_enabled = (SDL_GetWindowFlags(sdl_window) & SDL_WINDOW_FULLSCREEN) != 0;
     SDL_SetWindowFullscreen(sdl_window, !was_fullscreen_enabled);
 
+#ifndef __EMSCRIPTEN__
     SDL_WarpMouseGlobal(mouse_x_monitor_coordinate, mouse_y_monitor_coordinate);
+#endif
 
     menu_and_cursor_display_status.cursor_changes_to_ignore_count =
         menu_and_cursor_display_status.MAX_CURSOR_CHANGES_TO_IGNORE;
@@ -229,11 +236,13 @@ void handle_sdl_events(
 
                 if (key == key_bindings.fullscreen)
                 {
+#ifndef __EMSCRIPTEN__
                     if (is_key_pressed && !key_pressed_states.was_fullscreen_key_previously_pressed)
                     {
                         toggle_fullscreen_enabled_state(menu_and_cursor_display_status, sdl_window);
                     }
                     key_pressed_states.was_fullscreen_key_previously_pressed = is_key_pressed;
+#endif
                 }
                 else if (key == key_bindings.load_game_rom && is_key_pressed)
                 {

--- a/gui/src/input_events.cpp
+++ b/gui/src/input_events.cpp
@@ -99,7 +99,7 @@ static bool try_load_file_to_memory_from_path(
         {
             SDL_SetWindowTitle(
                 sdl_window,
-                std::string("Emulate Game Boy - " + game_boy_emulator.get_loaded_game_rom_title_thread_safe()).c_str());
+                std::string("Game Boy Emulator - " + game_boy_emulator.get_loaded_game_rom_title_thread_safe()).c_str());
         }
         emulation_controller.is_emulation_paused_atomic.store(false, std::memory_order_release);
         menu_and_cursor_display_status.cursor_changes_to_ignore_count =

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -281,11 +281,9 @@ int main()
             sdl_window.get(),
             game_boy_emulator.get_published_frame_sequence_number_thread_safe()
         };
-        // 0 = use requestAnimationFrame (browser controls frame rate)
-        // false = don't block (return control to browser immediately)
         start_emscripten_main_loop(loop_state);
-        // main() returns here but the loop continues via the browser event loop
-        // The RAII destructors must NOT run yet — Emscripten handles cleanup
+        // main() returns here but the loop continues via the browser event loop.
+        // Emscripten handles cleanup instead of the RAII destructors.
         emscripten_exit_with_live_runtime();
 #else
         while (!should_stop_emulation)

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -96,56 +96,6 @@ static bool resize_event_watch_callback(void* render_context_data, SDL_Event* sd
 
 #ifdef __EMSCRIPTEN__
 
-static int get_web_window_scale_for_viewport()
-{
-    const int viewport_width = EM_ASM_INT({ return window.innerWidth; });
-    const int viewport_height = EM_ASM_INT({ return window.innerHeight; });
-
-    return std::max(
-        1,
-        std::min(
-            viewport_width / DISPLAY_WIDTH_PIXELS,
-            viewport_height / DISPLAY_HEIGHT_PIXELS));
-}
-
-static void log_web_resize_diagnostics_if_changed(SDL_Window* sdl_window)
-{
-    const int viewport_width = EM_ASM_INT({ return window.innerWidth; });
-    const int viewport_height = EM_ASM_INT({ return window.innerHeight; });
-    const double device_pixel_ratio = EM_ASM_DOUBLE({ return window.devicePixelRatio; });
-    const int window_scale = get_web_window_scale_for_viewport();
-
-    int sdl_window_width, sdl_window_height;
-    SDL_GetWindowSize(sdl_window, &sdl_window_width, &sdl_window_height);
-
-    static int previous_viewport_width = -1;
-    static int previous_viewport_height = -1;
-    static int previous_sdl_window_width = -1;
-    static int previous_sdl_window_height = -1;
-    static int previous_window_scale = -1;
-
-    if (viewport_width != previous_viewport_width ||
-        viewport_height != previous_viewport_height ||
-        sdl_window_width != previous_sdl_window_width ||
-        sdl_window_height != previous_sdl_window_height ||
-        window_scale != previous_window_scale)
-    {
-        std::cout
-            << "[web-resize] viewport=" << viewport_width << "x" << viewport_height
-            << " dpr=" << device_pixel_ratio
-            << " scale=" << window_scale
-            << " target=" << (DISPLAY_WIDTH_PIXELS * window_scale) << "x" << (DISPLAY_HEIGHT_PIXELS * window_scale)
-            << " sdl=" << sdl_window_width << "x" << sdl_window_height
-            << "\n";
-
-        previous_viewport_width = viewport_width;
-        previous_viewport_height = viewport_height;
-        previous_sdl_window_width = sdl_window_width;
-        previous_sdl_window_height = sdl_window_height;
-        previous_window_scale = window_scale;
-    }
-}
-
 // Holds all state that the emscripten main loop callback needs
 struct EmscriptenLoopState
 {
@@ -191,8 +141,6 @@ static EM_BOOL emscripten_resize_callback(int, const EmscriptenUiEvent* ui_event
 static void emscripten_main_loop_iteration(void* arg)
 {
     EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(arg);
-
-    log_web_resize_diagnostics_if_changed(state->sdl_window);
 
     if (state->did_emulator_core_exception_occur_atomic->load(std::memory_order_acquire))
     {

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -353,6 +353,7 @@ int main()
         set_emulation_screen_blank(graphics_controller);
 
         uint8_t previously_published_frame_buffer_index = 0;
+        uint64_t previously_published_frame_sequence_number = 0;
         std::string error_message = "";
         bool should_stop_emulation = false;
 
@@ -406,6 +407,7 @@ int main()
             sdl_texture.get(),
             sdl_window.get(),
             &previously_published_frame_buffer_index,
+            &previously_published_frame_sequence_number,
             &persistent_settings.loaded_game_rom_path,
             &persistent_settings.loaded_boot_rom_path,
             false,

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -22,21 +22,36 @@
 #include "gui_state_types.h"
 #include "persistent_settings.h"
 
+struct WebThreadPacingState
+{
+    std::atomic<uint64_t> target_published_frame_sequence_number_atomic{};
+};
+
 static void run_emulator_core(
     std::stop_token stop_token,
     GameBoyEmulator::Emulator& game_boy_emulator,
     EmulationController& emulation_controller,
     std::atomic<bool>& did_exception_occur_atomic,
-    std::exception_ptr& exception_pointer)
+    std::exception_ptr& exception_pointer
+#ifdef __EMSCRIPTEN__
+    , WebThreadPacingState* web_thread_pacing_state
+#endif
+)
 {
     try
     {
+#ifdef __EMSCRIPTEN__
+        web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
+            game_boy_emulator.get_published_frame_sequence_number_thread_safe(),
+            std::memory_order_release);
+#else
         constexpr double FRAME_DURATION_SECONDS = 0.01674;
         const uint64_t counter_ticks_per_second = SDL_GetPerformanceFrequency();
         const uint64_t counter_ticks_per_frame_rounded = static_cast<uint64_t>(FRAME_DURATION_SECONDS * counter_ticks_per_second + 0.5);
 
         uint64_t next_frame_counter_tick = SDL_GetPerformanceCounter();
         uint8_t previously_published_frame_buffer_index = game_boy_emulator.get_published_frame_buffer_index_thread_safe();
+#endif
 
         while (!stop_token.stop_requested())
         {
@@ -44,10 +59,33 @@ static void run_emulator_core(
                 emulation_controller.is_emulation_paused_atomic.load(std::memory_order_acquire))
             {
                 SDL_Delay(0);
+#ifdef __EMSCRIPTEN__
+                web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
+                    game_boy_emulator.get_published_frame_sequence_number_thread_safe(),
+                    std::memory_order_release);
+#else
                 next_frame_counter_tick = SDL_GetPerformanceCounter();
                 previously_published_frame_buffer_index = game_boy_emulator.get_published_frame_buffer_index_thread_safe();
+#endif
                 continue;
             }
+
+#ifdef __EMSCRIPTEN__
+            const uint64_t target_published_frame_sequence_number =
+                web_thread_pacing_state->target_published_frame_sequence_number_atomic.load(std::memory_order_acquire);
+
+            if (game_boy_emulator.get_published_frame_sequence_number_thread_safe() >= target_published_frame_sequence_number)
+            {
+                SDL_Delay(0);
+                continue;
+            }
+
+            while (!stop_token.stop_requested() &&
+                   game_boy_emulator.get_published_frame_sequence_number_thread_safe() < target_published_frame_sequence_number)
+            {
+                game_boy_emulator.execute_next_instruction();
+            }
+#else
             game_boy_emulator.execute_next_instruction();
 
             const uint8_t currently_published_frame_buffer_index = game_boy_emulator.get_published_frame_buffer_index_thread_safe();
@@ -72,6 +110,7 @@ static void run_emulator_core(
                     next_frame_counter_tick = current_counter_tick;
                 }
             }
+#endif
         }
     }
     catch (...)
@@ -101,6 +140,7 @@ struct EmscriptenLoopState
 {
     GameBoyEmulator::Emulator* game_boy_emulator;
     EmulationController* emulation_controller;
+    WebThreadPacingState* web_thread_pacing_state;
     FileLoadingStatus* file_loading_status;
     MenuAndCursorDisplayStatus* menu_and_cursor_display_status;
     KeyPressedStates* key_pressed_states;
@@ -113,6 +153,7 @@ struct EmscriptenLoopState
     bool* should_stop_emulation;
     std::string* error_message;
     SDL_Window* sdl_window;
+    uint64_t target_published_frame_sequence_number;
 };
 
 static void sync_emscripten_window_to_viewport(
@@ -195,6 +236,28 @@ static void emscripten_main_loop_iteration(void* arg)
         emscripten_cancel_main_loop();
         return;
     }
+
+    if (!state->game_boy_emulator->is_game_rom_loaded_in_memory_thread_safe() ||
+        state->emulation_controller->is_emulation_paused_atomic.load(std::memory_order_acquire))
+    {
+        state->target_published_frame_sequence_number =
+            state->game_boy_emulator->get_published_frame_sequence_number_thread_safe();
+        state->web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
+            state->target_published_frame_sequence_number,
+            std::memory_order_release);
+        render_frame(*state->render_context);
+        return;
+    }
+
+    const double target_emulation_speed = state->emulation_controller->is_fast_forward_enabled_atomic.load(std::memory_order_acquire)
+        ? state->emulation_controller->target_fast_forward_multiplier_atomic.load(std::memory_order_acquire)
+        : 1.0;
+    const uint64_t frames_to_advance = std::max<uint64_t>(1, static_cast<uint64_t>(target_emulation_speed));
+    state->target_published_frame_sequence_number += frames_to_advance;
+    state->web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
+        state->target_published_frame_sequence_number,
+        std::memory_order_release);
+
     render_frame(*state->render_context);
 }
 
@@ -250,17 +313,25 @@ int main()
         EmulationController emulation_controller{};
         std::atomic<bool> did_emulator_core_exception_occur_atomic{};
         std::exception_ptr emulator_core_exception_pointer{};
+        WebThreadPacingState web_thread_pacing_state{};
         std::jthread emulator_thread
         {
             run_emulator_core,
             std::ref(game_boy_emulator),
             std::ref(emulation_controller),
             std::ref(did_emulator_core_exception_occur_atomic),
-            std::ref(emulator_core_exception_pointer),
+            std::ref(emulator_core_exception_pointer)
+#ifdef __EMSCRIPTEN__
+            , &web_thread_pacing_state
+#endif
         };
 
         FileLoadingStatus file_loading_status{};
         MenuAndCursorDisplayStatus menu_and_cursor_display_status{};
+        FrameDiagnosticsState frame_diagnostics_state{};
+#ifndef __EMSCRIPTEN__
+        frame_diagnostics_state.performance_counter_frequency = SDL_GetPerformanceFrequency();
+#endif
         constexpr uint32_t initial_custom_colour_palette[4] =
         {
             get_abgr_value_for_current_endianness(0xFF, 0xEF, 0xE0, 0x90),
@@ -327,6 +398,7 @@ int main()
             &emulation_controller,
             &file_loading_status,
             &menu_and_cursor_display_status,
+            &frame_diagnostics_state,
             &graphics_controller,
             &menu_properties,
             &key_bindings,
@@ -351,6 +423,7 @@ int main()
         {
             &game_boy_emulator,
             &emulation_controller,
+            &web_thread_pacing_state,
             &file_loading_status,
             &menu_and_cursor_display_status,
             &key_pressed_states,
@@ -362,7 +435,8 @@ int main()
             &persistent_settings,
             &should_stop_emulation,
             &error_message,
-            sdl_window.get()
+            sdl_window.get(),
+            game_boy_emulator.get_published_frame_sequence_number_thread_safe()
         };
         // 0 = use requestAnimationFrame (browser controls frame rate)
         // false = don't block (return control to browser immediately)

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -84,13 +84,11 @@ static void run_emulator_core(
 // Allows menu bar and the rendering rectangle to resize responsively while window size is being changed
 static bool resize_event_watch_callback(void* render_context_data, SDL_Event* sdl_event)
 {
-    if (sdl_event->type == SDL_EVENT_WINDOW_RESIZED ||
-        sdl_event->type == SDL_EVENT_WINDOW_MOVED)
+    if (sdl_event->type == SDL_EVENT_WINDOW_EXPOSED)
     {
         RenderContext* render_context = static_cast<RenderContext*>(render_context_data);
         update_imgui_scale_by_resolution(render_context->sdl_window);
-        constexpr bool should_skip_frame_data_update = false;
-        render_frame(*render_context, should_skip_frame_data_update);
+        render_frame(*render_context);
     }
     return true;
 }
@@ -145,9 +143,7 @@ static void emscripten_main_loop_iteration(void* arg)
         emscripten_cancel_main_loop();
         return;
     }
-
-    constexpr bool should_skip_frame_data_update = false;
-    render_frame(*state->render_context, should_skip_frame_data_update);
+    render_frame(*state->render_context);
 }
 
 #endif
@@ -337,8 +333,7 @@ int main()
                 should_stop_emulation,
                 error_message);
 
-            constexpr bool should_skip_frame_data_update = false;
-            render_frame(render_context, should_skip_frame_data_update);
+            render_frame(render_context);
         }
 
         game_boy_emulator.try_save_save_file(std::filesystem::path(SDL_GetBasePath()));

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -122,7 +122,7 @@ int main()
 #endif
         ResourceAcquisitionIsInitialization::SdlWindowRaii sdl_window
         {
-            "Emulate Game Boy",
+            "Game Boy Emulator",
             initial_window_w,
             initial_window_h,
             SDL_WINDOW_RESIZABLE
@@ -229,7 +229,7 @@ int main()
                     game_boy_emulator.reset_state();
                     SDL_SetWindowTitle(
                         sdl_window.get(),
-                        std::string("Emulate Game Boy - " + game_boy_emulator.get_loaded_game_rom_title_thread_safe()).c_str());
+                        std::string("Game Boy Emulator - " + game_boy_emulator.get_loaded_game_rom_title_thread_safe()).c_str());
                 }
             }
         }

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -320,9 +320,9 @@ int main()
             std::ref(game_boy_emulator),
             std::ref(emulation_controller),
             std::ref(did_emulator_core_exception_occur_atomic),
-            std::ref(emulator_core_exception_pointer)
+            std::ref(emulator_core_exception_pointer),
 #ifdef __EMSCRIPTEN__
-            , &web_thread_pacing_state
+            &web_thread_pacing_state
 #endif
         };
 

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -84,7 +84,8 @@ static void run_emulator_core(
 // Allows menu bar and the rendering rectangle to resize responsively while window size is being changed
 static bool resize_event_watch_callback(void* render_context_data, SDL_Event* sdl_event)
 {
-    if (sdl_event->type == SDL_EVENT_WINDOW_EXPOSED)
+    if (sdl_event->type == SDL_EVENT_WINDOW_EXPOSED ||
+        sdl_event->type == SDL_EVENT_WINDOW_RESIZED)
     {
         RenderContext* render_context = static_cast<RenderContext*>(render_context_data);
         update_imgui_scale_by_resolution(render_context->sdl_window);

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -113,8 +113,9 @@ int main()
         ResourceAcquisitionIsInitialization::SdlInitializerRaii sdl_initializer{SDL_INIT_VIDEO};
 
 #ifdef __EMSCRIPTEN__
-        const int initial_window_w = EM_ASM_INT({ return window.innerWidth; });
-        const int initial_window_h = EM_ASM_INT({ return window.innerHeight; });
+        const web_viewport_metrics_t initial_web_viewport_metrics = get_web_viewport_metrics();
+        const int initial_window_w = initial_web_viewport_metrics.pixel_viewport_width;
+        const int initial_window_h = initial_web_viewport_metrics.pixel_viewport_height;
 #else
         const int adaptive_window_scale = get_initial_window_scale_for_display();
         const int initial_window_w = DISPLAY_WIDTH_PIXELS * adaptive_window_scale;
@@ -144,6 +145,10 @@ int main()
         ResourceAcquisitionIsInitialization::ImGuiContextRaii imgui_context{sdl_window.get(), sdl_renderer.get()};
 
         update_imgui_scale_by_resolution(sdl_window.get());
+
+#ifdef __EMSCRIPTEN__
+        log_web_display_metrics(sdl_window.get(), "startup");
+#endif
 
 #if defined(__linux__) && !defined(__EMSCRIPTEN__)
         gtk_init(NULL, NULL);

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -43,39 +43,24 @@ static void run_emulator_core(
 
         while (!stop_token.stop_requested())
         {
-            if (!game_boy_emulator.is_game_rom_loaded_in_memory_thread_safe() ||
-                emulation_controller.is_emulation_paused_atomic.load(std::memory_order_acquire))
-            {
-                SDL_Delay(0);
+            if (!game_boy_emulator.is_game_rom_loaded_in_memory_thread_safe()
+                || emulation_controller.is_emulation_paused_atomic.load(std::memory_order_acquire)
 #ifdef __EMSCRIPTEN__
-                web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
-                    game_boy_emulator.get_published_frame_sequence_number_thread_safe(),
-                    std::memory_order_release);
-#else
+                || game_boy_emulator.get_published_frame_sequence_number_thread_safe() >=
+                   web_thread_pacing_state->target_published_frame_sequence_number_atomic.load(std::memory_order_acquire)
+#endif
+            )
+            {
+#ifndef __EMSCRIPTEN__
                 next_frame_counter_tick = SDL_GetPerformanceCounter();
                 previously_published_frame_buffer_index = game_boy_emulator.get_published_frame_buffer_index_thread_safe();
 #endif
-                continue;
-            }
-
-#ifdef __EMSCRIPTEN__
-            const uint64_t target_published_frame_sequence_number =
-                web_thread_pacing_state->target_published_frame_sequence_number_atomic.load(std::memory_order_acquire);
-
-            if (game_boy_emulator.get_published_frame_sequence_number_thread_safe() >= target_published_frame_sequence_number)
-            {
                 SDL_Delay(0);
                 continue;
             }
-
-            while (!stop_token.stop_requested() &&
-                   game_boy_emulator.get_published_frame_sequence_number_thread_safe() < target_published_frame_sequence_number)
-            {
-                game_boy_emulator.execute_next_instruction();
-            }
-#else
             game_boy_emulator.execute_next_instruction();
 
+#ifndef __EMSCRIPTEN__
             const uint8_t currently_published_frame_buffer_index = game_boy_emulator.get_published_frame_buffer_index_thread_safe();
 
             if (currently_published_frame_buffer_index != previously_published_frame_buffer_index)

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -1,13 +1,17 @@
 #include <atomic>
 #include <exception>
 #include <iostream>
-#include <nfd.h>
 #include <SDL3/SDL.h>
 #include <stop_token>
 #include <string>
 #include <thread>
 
-#ifdef __linux__
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#endif
+
+#if defined(__linux__) && !defined(__EMSCRIPTEN__)
 #include <gtk/gtk.h>
 #endif
 
@@ -85,11 +89,68 @@ static bool resize_event_watch_callback(void* render_context_data, SDL_Event* sd
     {
         RenderContext* render_context = static_cast<RenderContext*>(render_context_data);
         update_imgui_scale_by_resolution(render_context->sdl_window);
-        constexpr bool should_skip_frame_data_update = true;
+        constexpr bool should_skip_frame_data_update = false;
         render_frame(*render_context, should_skip_frame_data_update);
     }
     return true;
 }
+
+#ifdef __EMSCRIPTEN__
+
+// Holds all state that the emscripten main loop callback needs
+struct EmscriptenLoopState
+{
+    GameBoyEmulator::Emulator* game_boy_emulator;
+    EmulationController* emulation_controller;
+    FileLoadingStatus* file_loading_status;
+    MenuAndCursorDisplayStatus* menu_and_cursor_display_status;
+    KeyPressedStates* key_pressed_states;
+    KeyBindings* key_bindings;
+    MenuProperties* menu_properties;
+    RenderContext* render_context;
+    std::atomic<bool>* did_emulator_core_exception_occur_atomic;
+    std::exception_ptr* emulator_core_exception_pointer;
+    PersistentSettings* persistent_settings;
+    bool* should_stop_emulation;
+    std::string* error_message;
+    SDL_Window* sdl_window;
+};
+
+static void emscripten_main_loop_iteration(void* arg)
+{
+    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(arg);
+
+    if (state->did_emulator_core_exception_occur_atomic->load(std::memory_order_acquire))
+    {
+        emscripten_cancel_main_loop();
+        std::rethrow_exception(*state->emulator_core_exception_pointer);
+    }
+
+    handle_sdl_events(
+        *state->game_boy_emulator,
+        *state->emulation_controller,
+        *state->file_loading_status,
+        *state->menu_and_cursor_display_status,
+        *state->key_pressed_states,
+        *state->key_bindings,
+        *state->menu_properties,
+        state->sdl_window,
+        &state->persistent_settings->loaded_game_rom_path,
+        &state->persistent_settings->loaded_boot_rom_path,
+        *state->should_stop_emulation,
+        *state->error_message);
+
+    if (*state->should_stop_emulation)
+    {
+        emscripten_cancel_main_loop();
+        return;
+    }
+
+    constexpr bool should_skip_frame_data_update = false;
+    render_frame(*state->render_context, should_skip_frame_data_update);
+}
+
+#endif
 
 int main()
 {
@@ -123,10 +184,12 @@ int main()
 
         update_imgui_scale_by_resolution(sdl_window.get());
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(__EMSCRIPTEN__)
         gtk_init(NULL, NULL);
 #endif
+#ifndef __EMSCRIPTEN__
         ResourceAcquisitionIsInitialization::NfdInitializerRaii nfd_initializer{};
+#endif
 
         GameBoyEmulator::Emulator game_boy_emulator{};
         EmulationController emulation_controller{};
@@ -228,6 +291,31 @@ int main()
             &render_context
         };
 
+#ifdef __EMSCRIPTEN__
+        EmscriptenLoopState loop_state
+        {
+            &game_boy_emulator,
+            &emulation_controller,
+            &file_loading_status,
+            &menu_and_cursor_display_status,
+            &key_pressed_states,
+            &key_bindings,
+            &menu_properties,
+            &render_context,
+            &did_emulator_core_exception_occur_atomic,
+            &emulator_core_exception_pointer,
+            &persistent_settings,
+            &should_stop_emulation,
+            &error_message,
+            sdl_window.get()
+        };
+        // 0 = use requestAnimationFrame (browser controls frame rate)
+        // false = don't block (return control to browser immediately)
+        emscripten_set_main_loop_arg(emscripten_main_loop_iteration, &loop_state, 0, false);
+        // main() returns here but the loop continues via the browser event loop
+        // The RAII destructors must NOT run yet — Emscripten handles cleanup
+        emscripten_exit_with_live_runtime();
+#else
         while (!should_stop_emulation)
         {
             if (did_emulator_core_exception_occur_atomic.load(std::memory_order_acquire))
@@ -264,10 +352,11 @@ int main()
                 persistent_settings.loaded_boot_rom_path);
         save_settings_to_file(settings_to_save);
         return 0;
+#endif
     }
     catch (const std::exception& exception)
     {
         std::cerr << "Error: " << exception.what() << ", exiting.\n";
         return 1;
-    }   
+    }
 }

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -143,6 +143,9 @@ int main()
         };
         ResourceAcquisitionIsInitialization::ImGuiContextRaii imgui_context{sdl_window.get(), sdl_renderer.get()};
 
+#ifdef __EMSCRIPTEN__
+        sync_emscripten_canvas_to_viewport(sdl_window.get(), initial_window_w, initial_window_h);
+#endif
         update_imgui_scale_by_resolution(sdl_window.get());
 
 #if defined(__linux__) && !defined(__EMSCRIPTEN__)

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -180,6 +180,16 @@ static void emscripten_main_loop_iteration(void* arg)
         *state->should_stop_emulation,
         *state->error_message);
 
+    consume_pending_web_file_selection(
+        *state->game_boy_emulator,
+        *state->emulation_controller,
+        *state->file_loading_status,
+        *state->menu_and_cursor_display_status,
+        state->sdl_window,
+        &state->persistent_settings->loaded_game_rom_path,
+        &state->persistent_settings->loaded_boot_rom_path,
+        *state->error_message);
+
     if (*state->should_stop_emulation)
     {
         emscripten_cancel_main_loop();

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -146,10 +146,6 @@ int main()
 
         update_imgui_scale_by_resolution(sdl_window.get());
 
-#ifdef __EMSCRIPTEN__
-        log_web_display_metrics(sdl_window.get(), "startup");
-#endif
-
 #if defined(__linux__) && !defined(__EMSCRIPTEN__)
         gtk_init(NULL, NULL);
 #endif

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -8,7 +8,6 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-#include <emscripten/html5.h>
 #endif
 
 #if defined(__linux__) && !defined(__EMSCRIPTEN__)
@@ -21,30 +20,19 @@
 #include "raii_wrappers.h"
 #include "gui_state_types.h"
 #include "persistent_settings.h"
-
-struct WebThreadPacingState
-{
-    std::atomic<uint64_t> target_published_frame_sequence_number_atomic{};
-};
+#include "web_main_loop.h"
 
 static void run_emulator_core(
     std::stop_token stop_token,
     GameBoyEmulator::Emulator& game_boy_emulator,
     EmulationController& emulation_controller,
     std::atomic<bool>& did_exception_occur_atomic,
-    std::exception_ptr& exception_pointer
-#ifdef __EMSCRIPTEN__
-    , WebThreadPacingState* web_thread_pacing_state
-#endif
-)
+    std::exception_ptr& exception_pointer,
+    WebThreadPacingState* web_thread_pacing_state)
 {
     try
     {
-#ifdef __EMSCRIPTEN__
-        web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
-            game_boy_emulator.get_published_frame_sequence_number_thread_safe(),
-            std::memory_order_release);
-#else
+#ifndef __EMSCRIPTEN__
         constexpr double FRAME_DURATION_SECONDS = 0.01674;
         const uint64_t counter_ticks_per_second = SDL_GetPerformanceFrequency();
         const uint64_t counter_ticks_per_frame_rounded = static_cast<uint64_t>(FRAME_DURATION_SECONDS * counter_ticks_per_second + 0.5);
@@ -133,136 +121,6 @@ static bool resize_event_watch_callback(void* render_context_data, SDL_Event* sd
     return true;
 }
 
-#ifdef __EMSCRIPTEN__
-
-// Holds all state that the emscripten main loop callback needs
-struct EmscriptenLoopState
-{
-    GameBoyEmulator::Emulator* game_boy_emulator;
-    EmulationController* emulation_controller;
-    WebThreadPacingState* web_thread_pacing_state;
-    FileLoadingStatus* file_loading_status;
-    MenuAndCursorDisplayStatus* menu_and_cursor_display_status;
-    KeyPressedStates* key_pressed_states;
-    KeyBindings* key_bindings;
-    MenuProperties* menu_properties;
-    RenderContext* render_context;
-    std::atomic<bool>* did_emulator_core_exception_occur_atomic;
-    std::exception_ptr* emulator_core_exception_pointer;
-    PersistentSettings* persistent_settings;
-    bool* should_stop_emulation;
-    std::string* error_message;
-    SDL_Window* sdl_window;
-    uint64_t target_published_frame_sequence_number;
-};
-
-static void sync_emscripten_window_to_viewport(
-    EmscriptenLoopState* state,
-    int viewport_w,
-    int viewport_h)
-{
-    int sdl_w, sdl_h;
-    SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
-
-    if (viewport_w != sdl_w || viewport_h != sdl_h)
-    {
-        SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
-    }
-
-    update_imgui_scale_by_resolution(state->sdl_window);
-    render_frame(*state->render_context);
-}
-
-static EM_BOOL emscripten_resize_callback(int, const EmscriptenUiEvent* ui_event, void* user_data)
-{
-    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
-
-    const int viewport_w = ui_event->windowInnerWidth;
-    const int viewport_h = ui_event->windowInnerHeight;
-
-    sync_emscripten_window_to_viewport(state, viewport_w, viewport_h);
-
-    return EM_FALSE;
-}
-
-static EM_BOOL emscripten_fullscreen_change_callback(int, const EmscriptenFullscreenChangeEvent*, void* user_data)
-{
-    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
-
-    const int viewport_w = EM_ASM_INT({ return window.innerWidth; });
-    const int viewport_h = EM_ASM_INT({ return window.innerHeight; });
-
-    sync_emscripten_window_to_viewport(state, viewport_w, viewport_h);
-
-    return EM_FALSE;
-}
-
-static void emscripten_main_loop_iteration(void* arg)
-{
-    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(arg);
-
-    if (state->did_emulator_core_exception_occur_atomic->load(std::memory_order_acquire))
-    {
-        emscripten_cancel_main_loop();
-        std::rethrow_exception(*state->emulator_core_exception_pointer);
-    }
-
-    handle_sdl_events(
-        *state->game_boy_emulator,
-        *state->emulation_controller,
-        *state->file_loading_status,
-        *state->menu_and_cursor_display_status,
-        *state->key_pressed_states,
-        *state->key_bindings,
-        *state->menu_properties,
-        state->sdl_window,
-        &state->persistent_settings->loaded_game_rom_path,
-        &state->persistent_settings->loaded_boot_rom_path,
-        *state->should_stop_emulation,
-        *state->error_message);
-
-    consume_pending_web_file_selection(
-        *state->game_boy_emulator,
-        *state->emulation_controller,
-        *state->file_loading_status,
-        *state->menu_and_cursor_display_status,
-        state->sdl_window,
-        &state->persistent_settings->loaded_game_rom_path,
-        &state->persistent_settings->loaded_boot_rom_path,
-        *state->error_message);
-
-    if (*state->should_stop_emulation)
-    {
-        emscripten_cancel_main_loop();
-        return;
-    }
-
-    if (!state->game_boy_emulator->is_game_rom_loaded_in_memory_thread_safe() ||
-        state->emulation_controller->is_emulation_paused_atomic.load(std::memory_order_acquire))
-    {
-        state->target_published_frame_sequence_number =
-            state->game_boy_emulator->get_published_frame_sequence_number_thread_safe();
-        state->web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
-            state->target_published_frame_sequence_number,
-            std::memory_order_release);
-        render_frame(*state->render_context);
-        return;
-    }
-
-    const double target_emulation_speed = state->emulation_controller->is_fast_forward_enabled_atomic.load(std::memory_order_acquire)
-        ? state->emulation_controller->target_fast_forward_multiplier_atomic.load(std::memory_order_acquire)
-        : 1.0;
-    const uint64_t frames_to_advance = std::max<uint64_t>(1, static_cast<uint64_t>(target_emulation_speed));
-    state->target_published_frame_sequence_number += frames_to_advance;
-    state->web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
-        state->target_published_frame_sequence_number,
-        std::memory_order_release);
-
-    render_frame(*state->render_context);
-}
-
-#endif
-
 int main()
 {
     try
@@ -321,9 +179,7 @@ int main()
             std::ref(emulation_controller),
             std::ref(did_emulator_core_exception_occur_atomic),
             std::ref(emulator_core_exception_pointer),
-#ifdef __EMSCRIPTEN__
             &web_thread_pacing_state
-#endif
         };
 
         FileLoadingStatus file_loading_status{};
@@ -442,9 +298,7 @@ int main()
         };
         // 0 = use requestAnimationFrame (browser controls frame rate)
         // false = don't block (return control to browser immediately)
-        emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, &loop_state, false, emscripten_resize_callback);
-        emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, &loop_state, false, emscripten_fullscreen_change_callback);
-        emscripten_set_main_loop_arg(emscripten_main_loop_iteration, &loop_state, 0, false);
+        start_emscripten_main_loop(loop_state);
         // main() returns here but the loop continues via the browser event loop
         // The RAII destructors must NOT run yet — Emscripten handles cleanup
         emscripten_exit_with_live_runtime();

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -115,25 +115,43 @@ struct EmscriptenLoopState
     SDL_Window* sdl_window;
 };
 
+static void sync_emscripten_window_to_viewport(
+    EmscriptenLoopState* state,
+    int viewport_w,
+    int viewport_h)
+{
+    int sdl_w, sdl_h;
+    SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
+
+    if (viewport_w != sdl_w || viewport_h != sdl_h)
+    {
+        SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
+    }
+
+    update_imgui_scale_by_resolution(state->sdl_window);
+    render_frame(*state->render_context);
+}
+
 static EM_BOOL emscripten_resize_callback(int, const EmscriptenUiEvent* ui_event, void* user_data)
 {
     EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
 
-    const int viewport_w = (ui_event != nullptr)
-        ? ui_event->windowInnerWidth
-        : EM_ASM_INT({ return window.innerWidth; });
-    const int viewport_h = (ui_event != nullptr)
-        ? ui_event->windowInnerHeight
-        : EM_ASM_INT({ return window.innerHeight; });
+    const int viewport_w = ui_event->windowInnerWidth;
+    const int viewport_h = ui_event->windowInnerHeight;
 
-    int sdl_w, sdl_h;
-    SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
-    if (viewport_w != sdl_w || viewport_h != sdl_h)
-    {
-        SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
-        update_imgui_scale_by_resolution(state->sdl_window);
-        render_frame(*state->render_context);
-    }
+    sync_emscripten_window_to_viewport(state, viewport_w, viewport_h);
+
+    return EM_FALSE;
+}
+
+static EM_BOOL emscripten_fullscreen_change_callback(int, const EmscriptenFullscreenChangeEvent*, void* user_data)
+{
+    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
+
+    const int viewport_w = EM_ASM_INT({ return window.innerWidth; });
+    const int viewport_h = EM_ASM_INT({ return window.innerHeight; });
+
+    sync_emscripten_window_to_viewport(state, viewport_w, viewport_h);
 
     return EM_FALSE;
 }
@@ -339,6 +357,7 @@ int main()
         // 0 = use requestAnimationFrame (browser controls frame rate)
         // false = don't block (return control to browser immediately)
         emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, &loop_state, false, emscripten_resize_callback);
+        emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, &loop_state, false, emscripten_fullscreen_change_callback);
         emscripten_set_main_loop_arg(emscripten_main_loop_iteration, &loop_state, 0, false);
         // main() returns here but the loop continues via the browser event loop
         // The RAII destructors must NOT run yet — Emscripten handles cleanup

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -143,9 +143,6 @@ int main()
         };
         ResourceAcquisitionIsInitialization::ImGuiContextRaii imgui_context{sdl_window.get(), sdl_renderer.get()};
 
-#ifdef __EMSCRIPTEN__
-        sync_emscripten_canvas_to_viewport(sdl_window.get(), initial_window_w, initial_window_h);
-#endif
         update_imgui_scale_by_resolution(sdl_window.get());
 
 #if defined(__linux__) && !defined(__EMSCRIPTEN__)

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -96,6 +96,56 @@ static bool resize_event_watch_callback(void* render_context_data, SDL_Event* sd
 
 #ifdef __EMSCRIPTEN__
 
+static int get_web_window_scale_for_viewport()
+{
+    const int viewport_width = EM_ASM_INT({ return window.innerWidth; });
+    const int viewport_height = EM_ASM_INT({ return window.innerHeight; });
+
+    return std::max(
+        1,
+        std::min(
+            viewport_width / DISPLAY_WIDTH_PIXELS,
+            viewport_height / DISPLAY_HEIGHT_PIXELS));
+}
+
+static void log_web_resize_diagnostics_if_changed(SDL_Window* sdl_window)
+{
+    const int viewport_width = EM_ASM_INT({ return window.innerWidth; });
+    const int viewport_height = EM_ASM_INT({ return window.innerHeight; });
+    const double device_pixel_ratio = EM_ASM_DOUBLE({ return window.devicePixelRatio; });
+    const int window_scale = get_web_window_scale_for_viewport();
+
+    int sdl_window_width, sdl_window_height;
+    SDL_GetWindowSize(sdl_window, &sdl_window_width, &sdl_window_height);
+
+    static int previous_viewport_width = -1;
+    static int previous_viewport_height = -1;
+    static int previous_sdl_window_width = -1;
+    static int previous_sdl_window_height = -1;
+    static int previous_window_scale = -1;
+
+    if (viewport_width != previous_viewport_width ||
+        viewport_height != previous_viewport_height ||
+        sdl_window_width != previous_sdl_window_width ||
+        sdl_window_height != previous_sdl_window_height ||
+        window_scale != previous_window_scale)
+    {
+        std::cout
+            << "[web-resize] viewport=" << viewport_width << "x" << viewport_height
+            << " dpr=" << device_pixel_ratio
+            << " scale=" << window_scale
+            << " target=" << (DISPLAY_WIDTH_PIXELS * window_scale) << "x" << (DISPLAY_HEIGHT_PIXELS * window_scale)
+            << " sdl=" << sdl_window_width << "x" << sdl_window_height
+            << "\n";
+
+        previous_viewport_width = viewport_width;
+        previous_viewport_height = viewport_height;
+        previous_sdl_window_width = sdl_window_width;
+        previous_sdl_window_height = sdl_window_height;
+        previous_window_scale = window_scale;
+    }
+}
+
 // Holds all state that the emscripten main loop callback needs
 struct EmscriptenLoopState
 {
@@ -115,9 +165,34 @@ struct EmscriptenLoopState
     SDL_Window* sdl_window;
 };
 
+static EM_BOOL emscripten_resize_callback(int, const EmscriptenUiEvent* ui_event, void* user_data)
+{
+    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
+
+    const int viewport_w = (ui_event != nullptr)
+        ? ui_event->windowInnerWidth
+        : EM_ASM_INT({ return window.innerWidth; });
+    const int viewport_h = (ui_event != nullptr)
+        ? ui_event->windowInnerHeight
+        : EM_ASM_INT({ return window.innerHeight; });
+
+    int sdl_w, sdl_h;
+    SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
+    if (viewport_w != sdl_w || viewport_h != sdl_h)
+    {
+        SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
+        update_imgui_scale_by_resolution(state->sdl_window);
+        render_frame(*state->render_context);
+    }
+
+    return EM_FALSE;
+}
+
 static void emscripten_main_loop_iteration(void* arg)
 {
     EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(arg);
+
+    log_web_resize_diagnostics_if_changed(state->sdl_window);
 
     if (state->did_emulator_core_exception_occur_atomic->load(std::memory_order_acquire))
     {
@@ -155,12 +230,19 @@ int main()
     {
         ResourceAcquisitionIsInitialization::SdlInitializerRaii sdl_initializer{SDL_INIT_VIDEO};
 
+#ifdef __EMSCRIPTEN__
+        const int initial_window_w = EM_ASM_INT({ return window.innerWidth; });
+        const int initial_window_h = EM_ASM_INT({ return window.innerHeight; });
+#else
         const int adaptive_window_scale = get_initial_window_scale_for_display();
+        const int initial_window_w = DISPLAY_WIDTH_PIXELS * adaptive_window_scale;
+        const int initial_window_h = DISPLAY_HEIGHT_PIXELS * adaptive_window_scale;
+#endif
         ResourceAcquisitionIsInitialization::SdlWindowRaii sdl_window
         {
             "Emulate Game Boy",
-            DISPLAY_WIDTH_PIXELS * adaptive_window_scale,
-            DISPLAY_HEIGHT_PIXELS * adaptive_window_scale,
+            initial_window_w,
+            initial_window_h,
             SDL_WINDOW_RESIZABLE
         };
         ResourceAcquisitionIsInitialization::SdlRendererRaii sdl_renderer
@@ -308,6 +390,7 @@ int main()
         };
         // 0 = use requestAnimationFrame (browser controls frame rate)
         // false = don't block (return control to browser immediately)
+        emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, &loop_state, false, emscripten_resize_callback);
         emscripten_set_main_loop_arg(emscripten_main_loop_iteration, &loop_state, 0, false);
         // main() returns here but the loop continues via the browser event loop
         // The RAII destructors must NOT run yet — Emscripten handles cleanup

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -2,6 +2,8 @@
 
 #ifdef __EMSCRIPTEN__
 
+#include <algorithm>
+#include <cmath>
 #include <emscripten.h>
 #include <emscripten/html5.h>
 #include <iostream>
@@ -14,6 +16,13 @@ static void sync_emscripten_window_to_viewport(
     int viewport_w,
     int viewport_h)
 {
+    const double device_pixel_ratio = emscripten_get_device_pixel_ratio();
+    const int canvas_pixel_w = std::max(1, static_cast<int>(std::round(static_cast<double>(viewport_w) * device_pixel_ratio)));
+    const int canvas_pixel_h = std::max(1, static_cast<int>(std::round(static_cast<double>(viewport_h) * device_pixel_ratio)));
+
+    emscripten_set_canvas_element_size("#canvas", canvas_pixel_w, canvas_pixel_h);
+    emscripten_set_element_css_size("#canvas", static_cast<double>(viewport_w), static_cast<double>(viewport_h));
+
     int sdl_w, sdl_h;
     SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
 
@@ -24,6 +33,9 @@ static void sync_emscripten_window_to_viewport(
 
     std::cout << "[web_viewport] viewport_w=" << viewport_w
               << " viewport_h=" << viewport_h
+              << " device_pixel_ratio=" << device_pixel_ratio
+              << " canvas_pixel_w=" << canvas_pixel_w
+              << " canvas_pixel_h=" << canvas_pixel_h
               << " previous_sdl_w=" << sdl_w
               << " previous_sdl_h=" << sdl_h << "\n";
 

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -4,6 +4,7 @@
 
 #include <emscripten.h>
 #include <emscripten/html5.h>
+#include <iostream>
 
 #include "display_utilities.h"
 #include "input_events.h"
@@ -20,6 +21,11 @@ static void sync_emscripten_window_to_viewport(
     {
         SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
     }
+
+    std::cout << "[web_viewport] viewport_w=" << viewport_w
+              << " viewport_h=" << viewport_h
+              << " previous_sdl_w=" << sdl_w
+              << " previous_sdl_h=" << sdl_h << "\n";
 
     update_imgui_scale_by_resolution(state->sdl_window);
     render_frame(*state->render_context);

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -1,0 +1,123 @@
+#include "web_main_loop.h"
+
+#ifdef __EMSCRIPTEN__
+
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+#include "display_utilities.h"
+#include "input_events.h"
+
+static void sync_emscripten_window_to_viewport(
+    EmscriptenLoopState* state,
+    int viewport_w,
+    int viewport_h)
+{
+    int sdl_w, sdl_h;
+    SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
+
+    if (viewport_w != sdl_w || viewport_h != sdl_h)
+    {
+        SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
+    }
+
+    update_imgui_scale_by_resolution(state->sdl_window);
+    render_frame(*state->render_context);
+}
+
+static EM_BOOL emscripten_resize_callback(int, const EmscriptenUiEvent* ui_event, void* user_data)
+{
+    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
+
+    const int viewport_w = ui_event->windowInnerWidth;
+    const int viewport_h = ui_event->windowInnerHeight;
+
+    sync_emscripten_window_to_viewport(state, viewport_w, viewport_h);
+
+    return EM_FALSE;
+}
+
+static EM_BOOL emscripten_fullscreen_change_callback(int, const EmscriptenFullscreenChangeEvent*, void* user_data)
+{
+    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
+
+    const int viewport_w = EM_ASM_INT({ return window.innerWidth; });
+    const int viewport_h = EM_ASM_INT({ return window.innerHeight; });
+
+    sync_emscripten_window_to_viewport(state, viewport_w, viewport_h);
+
+    return EM_FALSE;
+}
+
+static void emscripten_main_loop_iteration(void* arg)
+{
+    EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(arg);
+
+    if (state->did_emulator_core_exception_occur_atomic->load(std::memory_order_acquire))
+    {
+        emscripten_cancel_main_loop();
+        std::rethrow_exception(*state->emulator_core_exception_pointer);
+    }
+
+    handle_sdl_events(
+        *state->game_boy_emulator,
+        *state->emulation_controller,
+        *state->file_loading_status,
+        *state->menu_and_cursor_display_status,
+        *state->key_pressed_states,
+        *state->key_bindings,
+        *state->menu_properties,
+        state->sdl_window,
+        &state->persistent_settings->loaded_game_rom_path,
+        &state->persistent_settings->loaded_boot_rom_path,
+        *state->should_stop_emulation,
+        *state->error_message);
+
+    consume_pending_web_file_selection(
+        *state->game_boy_emulator,
+        *state->emulation_controller,
+        *state->file_loading_status,
+        *state->menu_and_cursor_display_status,
+        state->sdl_window,
+        &state->persistent_settings->loaded_game_rom_path,
+        &state->persistent_settings->loaded_boot_rom_path,
+        *state->error_message);
+
+    if (*state->should_stop_emulation)
+    {
+        emscripten_cancel_main_loop();
+        return;
+    }
+
+    if (!state->game_boy_emulator->is_game_rom_loaded_in_memory_thread_safe() ||
+        state->emulation_controller->is_emulation_paused_atomic.load(std::memory_order_acquire))
+    {
+        state->target_published_frame_sequence_number =
+            state->game_boy_emulator->get_published_frame_sequence_number_thread_safe();
+        state->web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
+            state->target_published_frame_sequence_number,
+            std::memory_order_release);
+        render_frame(*state->render_context);
+        return;
+    }
+
+    const double target_emulation_speed = state->emulation_controller->is_fast_forward_enabled_atomic.load(std::memory_order_acquire)
+        ? state->emulation_controller->target_fast_forward_multiplier_atomic.load(std::memory_order_acquire)
+        : 1.0;
+    const uint64_t frames_to_advance = std::max<uint64_t>(1, static_cast<uint64_t>(target_emulation_speed));
+    state->target_published_frame_sequence_number += frames_to_advance;
+    state->web_thread_pacing_state->target_published_frame_sequence_number_atomic.store(
+        state->target_published_frame_sequence_number,
+        std::memory_order_release);
+
+    render_frame(*state->render_context);
+}
+
+void start_emscripten_main_loop(EmscriptenLoopState& loop_state)
+{
+    emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, &loop_state, false, emscripten_resize_callback);
+    emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, &loop_state, false, emscripten_fullscreen_change_callback);
+    emscripten_set_main_loop_arg(emscripten_main_loop_iteration, &loop_state, 0, false);
+}
+
+#endif

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -11,10 +11,7 @@
 #include "display_utilities.h"
 #include "input_events.h"
 
-static void sync_emscripten_window_to_viewport(
-    EmscriptenLoopState* state,
-    int viewport_w,
-    int viewport_h)
+void sync_emscripten_canvas_to_viewport(SDL_Window* sdl_window, int viewport_w, int viewport_h)
 {
     const double device_pixel_ratio = emscripten_get_device_pixel_ratio();
     const int canvas_pixel_w = std::max(1, static_cast<int>(std::round(static_cast<double>(viewport_w) * device_pixel_ratio)));
@@ -24,11 +21,11 @@ static void sync_emscripten_window_to_viewport(
     emscripten_set_element_css_size("#canvas", static_cast<double>(viewport_w), static_cast<double>(viewport_h));
 
     int sdl_w, sdl_h;
-    SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
+    SDL_GetWindowSize(sdl_window, &sdl_w, &sdl_h);
 
     if (viewport_w != sdl_w || viewport_h != sdl_h)
     {
-        SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
+        SDL_SetWindowSize(sdl_window, viewport_w, viewport_h);
     }
 
     std::cout << "[web_viewport] viewport_w=" << viewport_w
@@ -38,6 +35,14 @@ static void sync_emscripten_window_to_viewport(
               << " canvas_pixel_h=" << canvas_pixel_h
               << " previous_sdl_w=" << sdl_w
               << " previous_sdl_h=" << sdl_h << "\n";
+}
+
+static void sync_emscripten_window_to_viewport(
+    EmscriptenLoopState* state,
+    int viewport_w,
+    int viewport_h)
+{
+    sync_emscripten_canvas_to_viewport(state->sdl_window, viewport_w, viewport_h);
 
     update_imgui_scale_by_resolution(state->sdl_window);
     render_frame(*state->render_context);

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -2,8 +2,6 @@
 
 #ifdef __EMSCRIPTEN__
 
-#include <algorithm>
-#include <cmath>
 #include <emscripten.h>
 #include <emscripten/html5.h>
 #include <iostream>
@@ -16,13 +14,6 @@ static void sync_emscripten_window_to_viewport(
     int viewport_w,
     int viewport_h)
 {
-    const double device_pixel_ratio = emscripten_get_device_pixel_ratio();
-    const int canvas_pixel_w = std::max(1, static_cast<int>(std::round(static_cast<double>(viewport_w) * device_pixel_ratio)));
-    const int canvas_pixel_h = std::max(1, static_cast<int>(std::round(static_cast<double>(viewport_h) * device_pixel_ratio)));
-
-    emscripten_set_canvas_element_size("#canvas", canvas_pixel_w, canvas_pixel_h);
-    emscripten_set_element_css_size("#canvas", static_cast<double>(viewport_w), static_cast<double>(viewport_h));
-
     int sdl_w, sdl_h;
     SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
 
@@ -33,9 +24,6 @@ static void sync_emscripten_window_to_viewport(
 
     std::cout << "[web_viewport] viewport_w=" << viewport_w
               << " viewport_h=" << viewport_h
-              << " device_pixel_ratio=" << device_pixel_ratio
-              << " canvas_pixel_w=" << canvas_pixel_w
-              << " canvas_pixel_h=" << canvas_pixel_h
               << " previous_sdl_w=" << sdl_w
               << " previous_sdl_h=" << sdl_h << "\n";
 

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -4,7 +4,6 @@
 
 #include <emscripten.h>
 #include <emscripten/html5.h>
-#include <iostream>
 
 #include "display_utilities.h"
 #include "input_events.h"
@@ -21,11 +20,6 @@ static void sync_emscripten_window_to_viewport(
     {
         SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
     }
-
-    std::cout << "[web_viewport] viewport_w=" << viewport_w
-              << " viewport_h=" << viewport_h
-              << " previous_sdl_w=" << sdl_w
-              << " previous_sdl_h=" << sdl_h << "\n";
 
     update_imgui_scale_by_resolution(state->sdl_window);
     render_frame(*state->render_context);

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -9,8 +9,7 @@
 #include "input_events.h"
 
 static void sync_emscripten_window_to_viewport(
-    EmscriptenLoopState* state,
-    const char* reason)
+    EmscriptenLoopState* state)
 {
     const web_viewport_metrics_t viewport_metrics = get_web_viewport_metrics();
 
@@ -43,7 +42,7 @@ static EM_BOOL emscripten_resize_callback(int, const EmscriptenUiEvent* ui_event
     EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
     (void)ui_event;
 
-    sync_emscripten_window_to_viewport(state, "resize");
+    sync_emscripten_window_to_viewport(state);
 
     return EM_FALSE;
 }
@@ -52,7 +51,7 @@ static EM_BOOL emscripten_fullscreen_change_callback(int, const EmscriptenFullsc
 {
     EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
 
-    sync_emscripten_window_to_viewport(state, "fullscreenchange");
+    sync_emscripten_window_to_viewport(state);
 
     return EM_FALSE;
 }
@@ -125,7 +124,7 @@ void start_emscripten_main_loop(EmscriptenLoopState& loop_state)
 {
     emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, &loop_state, false, emscripten_resize_callback);
     emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, &loop_state, false, emscripten_fullscreen_change_callback);
-    sync_emscripten_window_to_viewport(&loop_state, "main-loop-start");
+    sync_emscripten_window_to_viewport(&loop_state);
     emscripten_set_main_loop_arg(emscripten_main_loop_iteration, &loop_state, 0, false);
 }
 

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -10,29 +10,41 @@
 
 static void sync_emscripten_window_to_viewport(
     EmscriptenLoopState* state,
-    int viewport_w,
-    int viewport_h)
+    const char* reason)
 {
+    const web_viewport_metrics_t viewport_metrics = get_web_viewport_metrics();
+
+    emscripten_set_element_css_size(
+        "#canvas",
+        static_cast<double>(viewport_metrics.css_viewport_width),
+        static_cast<double>(viewport_metrics.css_viewport_height));
+    emscripten_set_canvas_element_size(
+        "#canvas",
+        viewport_metrics.pixel_viewport_width,
+        viewport_metrics.pixel_viewport_height);
+
     int sdl_w, sdl_h;
     SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
 
-    if (viewport_w != sdl_w || viewport_h != sdl_h)
+    if (viewport_metrics.pixel_viewport_width != sdl_w || viewport_metrics.pixel_viewport_height != sdl_h)
     {
-        SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
+        SDL_SetWindowSize(
+            state->sdl_window,
+            viewport_metrics.pixel_viewport_width,
+            viewport_metrics.pixel_viewport_height);
     }
 
     update_imgui_scale_by_resolution(state->sdl_window);
+    log_web_display_metrics(state->sdl_window, reason);
     render_frame(*state->render_context);
 }
 
 static EM_BOOL emscripten_resize_callback(int, const EmscriptenUiEvent* ui_event, void* user_data)
 {
     EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
+    (void)ui_event;
 
-    const int viewport_w = ui_event->windowInnerWidth;
-    const int viewport_h = ui_event->windowInnerHeight;
-
-    sync_emscripten_window_to_viewport(state, viewport_w, viewport_h);
+    sync_emscripten_window_to_viewport(state, "resize");
 
     return EM_FALSE;
 }
@@ -41,10 +53,7 @@ static EM_BOOL emscripten_fullscreen_change_callback(int, const EmscriptenFullsc
 {
     EmscriptenLoopState* state = static_cast<EmscriptenLoopState*>(user_data);
 
-    const int viewport_w = EM_ASM_INT({ return window.innerWidth; });
-    const int viewport_h = EM_ASM_INT({ return window.innerHeight; });
-
-    sync_emscripten_window_to_viewport(state, viewport_w, viewport_h);
+    sync_emscripten_window_to_viewport(state, "fullscreenchange");
 
     return EM_FALSE;
 }
@@ -117,6 +126,7 @@ void start_emscripten_main_loop(EmscriptenLoopState& loop_state)
 {
     emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, &loop_state, false, emscripten_resize_callback);
     emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, &loop_state, false, emscripten_fullscreen_change_callback);
+    sync_emscripten_window_to_viewport(&loop_state, "main-loop-start");
     emscripten_set_main_loop_arg(emscripten_main_loop_iteration, &loop_state, 0, false);
 }
 

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -11,7 +11,10 @@
 #include "display_utilities.h"
 #include "input_events.h"
 
-void sync_emscripten_canvas_to_viewport(SDL_Window* sdl_window, int viewport_w, int viewport_h)
+static void sync_emscripten_window_to_viewport(
+    EmscriptenLoopState* state,
+    int viewport_w,
+    int viewport_h)
 {
     const double device_pixel_ratio = emscripten_get_device_pixel_ratio();
     const int canvas_pixel_w = std::max(1, static_cast<int>(std::round(static_cast<double>(viewport_w) * device_pixel_ratio)));
@@ -21,11 +24,11 @@ void sync_emscripten_canvas_to_viewport(SDL_Window* sdl_window, int viewport_w, 
     emscripten_set_element_css_size("#canvas", static_cast<double>(viewport_w), static_cast<double>(viewport_h));
 
     int sdl_w, sdl_h;
-    SDL_GetWindowSize(sdl_window, &sdl_w, &sdl_h);
+    SDL_GetWindowSize(state->sdl_window, &sdl_w, &sdl_h);
 
     if (viewport_w != sdl_w || viewport_h != sdl_h)
     {
-        SDL_SetWindowSize(sdl_window, viewport_w, viewport_h);
+        SDL_SetWindowSize(state->sdl_window, viewport_w, viewport_h);
     }
 
     std::cout << "[web_viewport] viewport_w=" << viewport_w
@@ -35,14 +38,6 @@ void sync_emscripten_canvas_to_viewport(SDL_Window* sdl_window, int viewport_w, 
               << " canvas_pixel_h=" << canvas_pixel_h
               << " previous_sdl_w=" << sdl_w
               << " previous_sdl_h=" << sdl_h << "\n";
-}
-
-static void sync_emscripten_window_to_viewport(
-    EmscriptenLoopState* state,
-    int viewport_w,
-    int viewport_h)
-{
-    sync_emscripten_canvas_to_viewport(state->sdl_window, viewport_w, viewport_h);
 
     update_imgui_scale_by_resolution(state->sdl_window);
     render_frame(*state->render_context);

--- a/gui/src/web_main_loop.cpp
+++ b/gui/src/web_main_loop.cpp
@@ -35,7 +35,6 @@ static void sync_emscripten_window_to_viewport(
     }
 
     update_imgui_scale_by_resolution(state->sdl_window);
-    log_web_display_metrics(state->sdl_window, reason);
     render_frame(*state->render_context);
 }
 

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -11,18 +11,24 @@
             box-sizing: border-box;
         }
 
+        html {
+            width: 100%;
+            height: 100%;
+        }
+
         body {
             background-color: #000;
             overflow: hidden;
-            width: 100vw;
-            height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
+            width: 100%;
+            height: 100%;
         }
 
         canvas {
+            position: fixed;
+            inset: 0;
             display: block;
+            width: 100vw;
+            height: 100vh;
             image-rendering: pixelated;
             outline: none;
         }
@@ -40,19 +46,6 @@
 
         window.addEventListener('load', function() {
             const canvas = document.getElementById('canvas');
-
-            function pinCanvasCssSize() {
-                // Always express the canvas in CSS pixels (buffer px / DPR).
-                // Never clear the CSS size — doing so lets the browser
-                // upscale the buffer and cause blur in fullscreen.
-                canvas.style.width  = Math.round(canvas.width  / window.devicePixelRatio) + 'px';
-                canvas.style.height = Math.round(canvas.height / window.devicePixelRatio) + 'px';
-            }
-
-            const observer = new MutationObserver(pinCanvasCssSize);
-            observer.observe(canvas, { attributes: true, attributeFilter: ['width', 'height'] });
-
-            document.addEventListener('fullscreenchange', pinCanvasCssSize);
         });
     </script>
     {{{ SCRIPT }}}

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -39,7 +39,7 @@
     </style>
 </head>
 <body>
-    <canvas id="canvas" tabindex="0"></canvas>
+    <canvas id="canvas" width="160" height="144" tabindex="0"></canvas>
     <input id="rom-file-input" type="file" accept=".gb,.gbc,.bin,.rom" style="display: none;">
     <script>
         window.Module = window.Module || {};

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -40,6 +40,10 @@
     <input id="rom-file-input" type="file" accept=".gb,.gbc,.bin,.rom" style="display: none;">
     <script>
         window.Module = window.Module || {};
+        window.Module.isWebCursorVisible = true;
+        window.Module.setWebCursorVisible = window.Module.setWebCursorVisible || function(isVisible) {
+            window.Module.isWebCursorVisible = isVisible;
+        };
 
         document.addEventListener('DOMContentLoaded', function() {
             const module = window.Module;
@@ -57,6 +61,13 @@
                 canvas.focus({ preventScroll: true });
             }
 
+            function applyWebCursorVisibility() {
+                const cursorStyle = module.isWebCursorVisible ? 'default' : 'none';
+                canvas.style.cursor = cursorStyle;
+                document.body.style.cursor = cursorStyle;
+                document.documentElement.style.cursor = cursorStyle;
+            }
+
             function reportWebFileSelectionResult(fileType, result) {
                 const callback = module._set_pending_web_file_selection_result;
                 if (typeof callback === 'function') {
@@ -69,6 +80,11 @@
                     FS.mkdir('/tmp');
                 }
             }
+
+            module.setWebCursorVisible = function(isVisible) {
+                module.isWebCursorVisible = isVisible;
+                applyWebCursorVisibility();
+            };
 
             function handleFilePickerCancelled() {
                 window.setTimeout(function() {
@@ -133,6 +149,7 @@
             });
 
             focusCanvas();
+            applyWebCursorVisibility();
 
             document.addEventListener('click', function() {
                 focusCanvas();

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -72,6 +72,19 @@
                 document.documentElement.style.cursor = cursor_style;
             }
 
+            function sync_canvas_backing_resolution()
+            {
+                const device_pixel_ratio = window.devicePixelRatio || 1;
+                const backing_width = Math.max(1, Math.round(window.innerWidth * device_pixel_ratio));
+                const backing_height = Math.max(1, Math.round(window.innerHeight * device_pixel_ratio));
+
+                if (canvas.width !== backing_width || canvas.height !== backing_height)
+                {
+                    canvas.width = backing_width;
+                    canvas.height = backing_height;
+                }
+            }
+
             function log_web_metrics(source)
             {
                 console.log('[web_shell]', source,
@@ -181,6 +194,7 @@
             });
 
             focus_canvas();
+            sync_canvas_backing_resolution();
             apply_web_cursor_visibility();
             log_web_metrics('dom_content_loaded');
 
@@ -191,6 +205,7 @@
 
             window.addEventListener('resize', function()
             {
+                sync_canvas_backing_resolution();
                 log_web_metrics('window_resize');
             });
 

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -35,8 +35,24 @@
         document.addEventListener('DOMContentLoaded', function() {
             const canvas = document.getElementById('canvas');
             canvas.focus();
-            // Re-focus if user clicks anywhere on the page
             document.addEventListener('click', function() { canvas.focus(); });
+        });
+
+        window.addEventListener('load', function() {
+            const canvas = document.getElementById('canvas');
+
+            function pinCanvasCssSize() {
+                // Always express the canvas in CSS pixels (buffer px / DPR).
+                // Never clear the CSS size — doing so lets the browser
+                // upscale the buffer and cause blur in fullscreen.
+                canvas.style.width  = Math.round(canvas.width  / window.devicePixelRatio) + 'px';
+                canvas.style.height = Math.round(canvas.height / window.devicePixelRatio) + 'px';
+            }
+
+            const observer = new MutationObserver(pinCanvasCssSize);
+            observer.observe(canvas, { attributes: true, attributeFilter: ['width', 'height'] });
+
+            document.addEventListener('fullscreenchange', pinCanvasCssSize);
         });
     </script>
     {{{ SCRIPT }}}

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -37,13 +37,100 @@
 </head>
 <body>
     <canvas id="canvas" width="160" height="144" tabindex="0"></canvas>
+    <input id="rom-file-input" type="file" accept=".gb,.gbc,.bin,.rom" style="display: none;">
     <script>
+        window.Module = window.Module || {};
+
         document.addEventListener('DOMContentLoaded', function() {
+            const module = window.Module;
             const canvas = document.getElementById('canvas');
+            const romFileInput = document.getElementById('rom-file-input');
+            const webSelectedPaths = {
+                0: '/tmp/web-selected-game-rom.gb',
+                1: '/tmp/web-selected-boot-rom.bin'
+            };
+            let pendingFileType = 0;
+            let isFilePickerOpen = false;
+            let isFileSelectionHandled = false;
 
             function focusCanvas() {
                 canvas.focus({ preventScroll: true });
             }
+
+            function reportWebFileSelectionResult(fileType, result) {
+                const callback = module._set_pending_web_file_selection_result;
+                if (typeof callback === 'function') {
+                    callback(fileType, result);
+                }
+            }
+
+            function ensureWebRomDirectory() {
+                if (!FS.analyzePath('/tmp').exists) {
+                    FS.mkdir('/tmp');
+                }
+            }
+
+            function handleFilePickerCancelled() {
+                window.setTimeout(function() {
+                    if (isFilePickerOpen && !isFileSelectionHandled && romFileInput.files.length === 0) {
+                        isFilePickerOpen = false;
+                        reportWebFileSelectionResult(pendingFileType, 3);
+                        focusCanvas();
+                    }
+                }, 0);
+            }
+
+            module.openRomFilePicker = function(fileType) {
+                pendingFileType = fileType;
+                isFilePickerOpen = true;
+                isFileSelectionHandled = false;
+                romFileInput.value = '';
+                romFileInput.click();
+            };
+
+            romFileInput.addEventListener('change', function(event) {
+                const [selectedFile] = event.target.files;
+
+                if (!selectedFile) {
+                    isFilePickerOpen = false;
+                    isFileSelectionHandled = true;
+                    reportWebFileSelectionResult(pendingFileType, 3);
+                    focusCanvas();
+                    return;
+                }
+
+                isFilePickerOpen = false;
+                isFileSelectionHandled = true;
+
+                const reader = new FileReader();
+
+                reader.addEventListener('load', function(loadEvent) {
+                    try {
+                        ensureWebRomDirectory();
+
+                        const romPath = webSelectedPaths[pendingFileType] ?? webSelectedPaths[0];
+                        const romBytes = new Uint8Array(loadEvent.target.result);
+
+                        if (FS.analyzePath(romPath).exists) {
+                            FS.unlink(romPath);
+                        }
+
+                        FS.writeFile(romPath, romBytes);
+                        reportWebFileSelectionResult(pendingFileType, 2);
+                    } catch {
+                        reportWebFileSelectionResult(pendingFileType, 4);
+                    }
+
+                    focusCanvas();
+                });
+
+                reader.addEventListener('error', function() {
+                    reportWebFileSelectionResult(pendingFileType, 4);
+                    focusCanvas();
+                });
+
+                reader.readAsArrayBuffer(selectedFile);
+            });
 
             focusCanvas();
 
@@ -54,6 +141,8 @@
             document.addEventListener('fullscreenchange', function() {
                 focusCanvas();
             });
+
+            window.addEventListener('focus', handleFilePickerCancelled);
         });
     </script>
     {{{ SCRIPT }}}

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -39,7 +39,7 @@
     </style>
 </head>
 <body>
-    <canvas id="canvas" width="160" height="144" tabindex="0"></canvas>
+    <canvas id="canvas" tabindex="0"></canvas>
     <input id="rom-file-input" type="file" accept=".gb,.gbc,.bin,.rom" style="display: none;">
     <script>
         window.Module = window.Module || {};

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -43,10 +43,6 @@
             canvas.focus();
             document.addEventListener('click', function() { canvas.focus(); });
         });
-
-        window.addEventListener('load', function() {
-            const canvas = document.getElementById('canvas');
-        });
     </script>
     {{{ SCRIPT }}}
 </body>

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -72,19 +72,6 @@
                 document.documentElement.style.cursor = cursor_style;
             }
 
-            function sync_canvas_backing_resolution()
-            {
-                const device_pixel_ratio = window.devicePixelRatio || 1;
-                const backing_width = Math.max(1, Math.round(window.innerWidth * device_pixel_ratio));
-                const backing_height = Math.max(1, Math.round(window.innerHeight * device_pixel_ratio));
-
-                if (canvas.width !== backing_width || canvas.height !== backing_height)
-                {
-                    canvas.width = backing_width;
-                    canvas.height = backing_height;
-                }
-            }
-
             function log_web_metrics(source)
             {
                 console.log('[web_shell]', source,
@@ -194,7 +181,6 @@
             });
 
             focus_canvas();
-            sync_canvas_backing_resolution();
             apply_web_cursor_visibility();
             log_web_metrics('dom_content_loaded');
 
@@ -205,7 +191,6 @@
 
             window.addEventListener('resize', function()
             {
-                sync_canvas_backing_resolution();
                 log_web_metrics('window_resize');
             });
 

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -72,17 +72,6 @@
                 document.documentElement.style.cursor = cursor_style;
             }
 
-            function log_web_metrics(source)
-            {
-                console.log('[web_shell]', source,
-                    'inner', window.innerWidth, window.innerHeight,
-                    'outer', window.outerWidth, window.outerHeight,
-                    'screen', window.screen.width, window.screen.height,
-                    'dpr', window.devicePixelRatio || 1,
-                    'canvas_client', canvas.clientWidth, canvas.clientHeight,
-                    'canvas_backing', canvas.width, canvas.height);
-            }
-
             function report_web_file_selection_result(file_type, result)
             {
                 const callback = module._set_pending_web_file_selection_result;
@@ -182,16 +171,10 @@
 
             focus_canvas();
             apply_web_cursor_visibility();
-            log_web_metrics('dom_content_loaded');
 
             document.addEventListener('click', function()
             {
                 focus_canvas();
-            });
-
-            window.addEventListener('resize', function()
-            {
-                log_web_metrics('window_resize');
             });
 
             window.addEventListener('focus', handle_file_picker_cancelled);

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -40,8 +40,20 @@
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const canvas = document.getElementById('canvas');
-            canvas.focus();
-            document.addEventListener('click', function() { canvas.focus(); });
+
+            function focusCanvas() {
+                canvas.focus({ preventScroll: true });
+            }
+
+            focusCanvas();
+
+            document.addEventListener('click', function() {
+                focusCanvas();
+            });
+
+            document.addEventListener('fullscreenchange', function() {
+                focusCanvas();
+            });
         });
     </script>
     {{{ SCRIPT }}}

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -72,6 +72,17 @@
                 document.documentElement.style.cursor = cursor_style;
             }
 
+            function log_web_metrics(source)
+            {
+                console.log('[web_shell]', source,
+                    'inner', window.innerWidth, window.innerHeight,
+                    'outer', window.outerWidth, window.outerHeight,
+                    'screen', window.screen.width, window.screen.height,
+                    'dpr', window.devicePixelRatio || 1,
+                    'canvas_client', canvas.clientWidth, canvas.clientHeight,
+                    'canvas_backing', canvas.width, canvas.height);
+            }
+
             function report_web_file_selection_result(file_type, result)
             {
                 const callback = module._set_pending_web_file_selection_result;
@@ -171,10 +182,16 @@
 
             focus_canvas();
             apply_web_cursor_visibility();
+            log_web_metrics('dom_content_loaded');
 
             document.addEventListener('click', function()
             {
                 focus_canvas();
+            });
+
+            window.addEventListener('resize', function()
+            {
+                log_web_metrics('window_resize');
             });
 
             window.addEventListener('focus', handle_file_picker_cancelled);

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Game Boy Emulator</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            background-color: #000;
+            overflow: hidden;
+            width: 100vw;
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        canvas {
+            display: block;
+            image-rendering: pixelated;
+            outline: none;
+        }
+    </style>
+
+</head>
+<body>
+    <canvas id="canvas" width="160" height="144" tabindex="0"></canvas>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const canvas = document.getElementById('canvas');
+            canvas.focus();
+            // Re-focus if user clicks anywhere on the page
+            document.addEventListener('click', function() { canvas.focus(); });
+        });
+    </script>
+    {{{ SCRIPT }}}
+</body>
+</html>

--- a/gui/web/shell.html
+++ b/gui/web/shell.html
@@ -5,25 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Game Boy Emulator</title>
     <style>
-        * {
+        *
+        {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
         }
 
-        html {
+        html
+        {
             width: 100%;
             height: 100%;
         }
 
-        body {
+        body
+        {
             background-color: #000;
             overflow: hidden;
             width: 100%;
             height: 100%;
         }
 
-        canvas {
+        canvas
+        {
             position: fixed;
             inset: 0;
             display: block;
@@ -33,133 +37,147 @@
             outline: none;
         }
     </style>
-
 </head>
 <body>
     <canvas id="canvas" width="160" height="144" tabindex="0"></canvas>
     <input id="rom-file-input" type="file" accept=".gb,.gbc,.bin,.rom" style="display: none;">
     <script>
         window.Module = window.Module || {};
-        window.Module.isWebCursorVisible = true;
-        window.Module.setWebCursorVisible = window.Module.setWebCursorVisible || function(isVisible) {
-            window.Module.isWebCursorVisible = isVisible;
-        };
+        window.Module.is_web_cursor_visible = true;
 
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function()
+        {
             const module = window.Module;
             const canvas = document.getElementById('canvas');
-            const romFileInput = document.getElementById('rom-file-input');
-            const webSelectedPaths = {
+            const rom_file_input = document.getElementById('rom-file-input');
+            const web_selected_paths =
+            {
                 0: '/tmp/web-selected-game-rom.gb',
                 1: '/tmp/web-selected-boot-rom.bin'
             };
-            let pendingFileType = 0;
-            let isFilePickerOpen = false;
-            let isFileSelectionHandled = false;
+            let pending_file_type = 0;
+            let is_file_picker_open = false;
+            let is_file_selection_handled = false;
 
-            function focusCanvas() {
+            function focus_canvas()
+            {
                 canvas.focus({ preventScroll: true });
             }
 
-            function applyWebCursorVisibility() {
-                const cursorStyle = module.isWebCursorVisible ? 'default' : 'none';
-                canvas.style.cursor = cursorStyle;
-                document.body.style.cursor = cursorStyle;
-                document.documentElement.style.cursor = cursorStyle;
+            function apply_web_cursor_visibility()
+            {
+                const cursor_style = module.is_web_cursor_visible ? 'default' : 'none';
+                canvas.style.cursor = cursor_style;
+                document.body.style.cursor = cursor_style;
+                document.documentElement.style.cursor = cursor_style;
             }
 
-            function reportWebFileSelectionResult(fileType, result) {
+            function report_web_file_selection_result(file_type, result)
+            {
                 const callback = module._set_pending_web_file_selection_result;
-                if (typeof callback === 'function') {
-                    callback(fileType, result);
+                if (typeof callback === 'function')
+                {
+                    callback(file_type, result);
                 }
             }
 
-            function ensureWebRomDirectory() {
-                if (!FS.analyzePath('/tmp').exists) {
+            function ensure_web_rom_directory()
+            {
+                if (!FS.analyzePath('/tmp').exists)
+                {
                     FS.mkdir('/tmp');
                 }
             }
 
-            module.setWebCursorVisible = function(isVisible) {
-                module.isWebCursorVisible = isVisible;
-                applyWebCursorVisibility();
+            module.setWebCursorVisible = function(is_visible)
+            {
+                module.is_web_cursor_visible = is_visible;
+                apply_web_cursor_visibility();
             };
 
-            function handleFilePickerCancelled() {
-                window.setTimeout(function() {
-                    if (isFilePickerOpen && !isFileSelectionHandled && romFileInput.files.length === 0) {
-                        isFilePickerOpen = false;
-                        reportWebFileSelectionResult(pendingFileType, 3);
-                        focusCanvas();
+            function handle_file_picker_cancelled()
+            {
+                window.setTimeout(function()
+                {
+                    if (is_file_picker_open && !is_file_selection_handled && rom_file_input.files.length === 0)
+                    {
+                        is_file_picker_open = false;
+                        report_web_file_selection_result(pending_file_type, 3);
+                        focus_canvas();
                     }
                 }, 0);
             }
 
-            module.openRomFilePicker = function(fileType) {
-                pendingFileType = fileType;
-                isFilePickerOpen = true;
-                isFileSelectionHandled = false;
-                romFileInput.value = '';
-                romFileInput.click();
+            module.openRomFilePicker = function(file_type)
+            {
+                pending_file_type = file_type;
+                is_file_picker_open = true;
+                is_file_selection_handled = false;
+                rom_file_input.value = '';
+                rom_file_input.click();
             };
 
-            romFileInput.addEventListener('change', function(event) {
-                const [selectedFile] = event.target.files;
+            rom_file_input.addEventListener('change', function(event)
+            {
+                const [selected_file] = event.target.files;
 
-                if (!selectedFile) {
-                    isFilePickerOpen = false;
-                    isFileSelectionHandled = true;
-                    reportWebFileSelectionResult(pendingFileType, 3);
-                    focusCanvas();
+                if (!selected_file)
+                {
+                    is_file_picker_open = false;
+                    is_file_selection_handled = true;
+                    report_web_file_selection_result(pending_file_type, 3);
+                    focus_canvas();
                     return;
                 }
 
-                isFilePickerOpen = false;
-                isFileSelectionHandled = true;
+                is_file_picker_open = false;
+                is_file_selection_handled = true;
 
                 const reader = new FileReader();
 
-                reader.addEventListener('load', function(loadEvent) {
-                    try {
-                        ensureWebRomDirectory();
+                reader.addEventListener('load', function(load_event)
+                {
+                    try
+                    {
+                        ensure_web_rom_directory();
 
-                        const romPath = webSelectedPaths[pendingFileType] ?? webSelectedPaths[0];
-                        const romBytes = new Uint8Array(loadEvent.target.result);
+                        const rom_path = web_selected_paths[pending_file_type] ?? web_selected_paths[0];
+                        const rom_bytes = new Uint8Array(load_event.target.result);
 
-                        if (FS.analyzePath(romPath).exists) {
-                            FS.unlink(romPath);
+                        if (FS.analyzePath(rom_path).exists)
+                        {
+                            FS.unlink(rom_path);
                         }
 
-                        FS.writeFile(romPath, romBytes);
-                        reportWebFileSelectionResult(pendingFileType, 2);
-                    } catch {
-                        reportWebFileSelectionResult(pendingFileType, 4);
+                        FS.writeFile(rom_path, rom_bytes);
+                        report_web_file_selection_result(pending_file_type, 2);
+                    }
+                    catch
+                    {
+                        report_web_file_selection_result(pending_file_type, 4);
                     }
 
-                    focusCanvas();
+                    focus_canvas();
                 });
 
-                reader.addEventListener('error', function() {
-                    reportWebFileSelectionResult(pendingFileType, 4);
-                    focusCanvas();
+                reader.addEventListener('error', function()
+                {
+                    report_web_file_selection_result(pending_file_type, 4);
+                    focus_canvas();
                 });
 
-                reader.readAsArrayBuffer(selectedFile);
+                reader.readAsArrayBuffer(selected_file);
             });
 
-            focusCanvas();
-            applyWebCursorVisibility();
+            focus_canvas();
+            apply_web_cursor_visibility();
 
-            document.addEventListener('click', function() {
-                focusCanvas();
+            document.addEventListener('click', function()
+            {
+                focus_canvas();
             });
 
-            document.addEventListener('fullscreenchange', function() {
-                focusCanvas();
-            });
-
-            window.addEventListener('focus', handleFilePickerCancelled);
+            window.addEventListener('focus', handle_file_picker_cancelled);
         });
     </script>
     {{{ SCRIPT }}}


### PR DESCRIPTION
- Create a web port for the emulator with Emscripten.
- Create a workflow to auto-deploy the newest version on push to `main`.
- Update the `README.md` with a link to the latest web version.
- Update default keybindings to be more web-friendly.
- Add debug window to desktop version with some performance metrics like FPS and skipped frames.