### PR TITLE
Add Test Reporting to the run-tests Workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,24 +45,18 @@ jobs:
             --target game-boy-tests
 
       - name: Run Tests
-        id: run_tests
-        continue-on-error: true
         run: |
-          ctest \
-            --test-dir build \
-            --parallel $(nproc) \
-            --output-on-failure \
-            --output-junit ctest-results.xml
+          ./build/bin/game-boy-tests \
+            --gtest_output=xml:build/gtest-results.xml
 
       - if: always()
         name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
         with:
-          report_paths: build/ctest-results.xml
+          report_paths: build/gtest-results.xml
           fail_on_failure: true
           include_passed: true
           detailed_summary: true
           job_summary: true
           annotate_only: true
           skip_annotations: true
-          resolve_ignore_classname: true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -60,3 +60,4 @@ jobs:
           job_summary: true
           annotate_only: true
           skip_annotations: true
+          resolve_ignore_classname: true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,6 +55,25 @@ jobs:
             --output-junit build/ctest-results.xml
 
       - if: always()
+        name: Debug Test Report Output
+        run: |
+          echo "Listing build directory contents"
+          ls -la build || true
+          echo "Listing build/Testing directory contents"
+          ls -la build/Testing || true
+          echo "Searching for XML test reports under build"
+          find build -maxdepth 3 -type f \( -name '*.xml' -o -name 'Test.xml' \) -print || true
+          echo "Checking for build/ctest-results.xml"
+          if [ -f build/ctest-results.xml ]; then
+            echo "Found build/ctest-results.xml"
+            wc -c build/ctest-results.xml || true
+            echo "Preview of build/ctest-results.xml"
+            sed -n '1,120p' build/ctest-results.xml || true
+          else
+            echo "build/ctest-results.xml was not generated"
+          fi
+
+      - if: always()
         name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
         with:
@@ -63,3 +82,5 @@ jobs:
           include_passed: true
           detailed_summary: true
           job_summary: true
+          annotate_only: true
+          skip_annotations: true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -54,8 +54,8 @@ jobs:
             --output-on-failure \
             --output-junit build/ctest-results.xml
 
-      - name: Publish Test Report
-        if: always()
+      - if: always()
+        name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: build/ctest-results.xml

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,25 +55,6 @@ jobs:
             --output-junit ctest-results.xml
 
       - if: always()
-        name: Debug Test Report Output
-        run: |
-          echo "Listing build directory contents"
-          ls -la build || true
-          echo "Listing build/Testing directory contents"
-          ls -la build/Testing || true
-          echo "Searching for XML test reports under build"
-          find build -maxdepth 3 -type f \( -name '*.xml' -o -name 'Test.xml' \) -print || true
-          echo "Checking for build/ctest-results.xml"
-          if [ -f build/ctest-results.xml ]; then
-            echo "Found build/ctest-results.xml"
-            wc -c build/ctest-results.xml || true
-            echo "Preview of build/ctest-results.xml"
-            sed -n '1,120p' build/ctest-results.xml || true
-          else
-            echo "build/ctest-results.xml was not generated"
-          fi
-
-      - if: always()
         name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
         with:
@@ -84,3 +65,4 @@ jobs:
           job_summary: true
           annotate_only: true
           skip_annotations: true
+          resolve_ignore_classname: true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -52,7 +52,7 @@ jobs:
             --test-dir build \
             --parallel $(nproc) \
             --output-on-failure \
-            --output-junit build/ctest-results.xml
+            --output-junit ctest-results.xml
 
       - if: always()
         name: Debug Test Report Output

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,8 +45,21 @@ jobs:
             --target game-boy-tests
 
       - name: Run Tests
+        id: run_tests
+        continue-on-error: true
         run: |
           ctest \
             --test-dir build \
             --parallel $(nproc) \
-            --output-on-failure
+            --output-on-failure \
+            --output-junit build/ctest-results.xml
+
+      - name: Publish Test Report
+        if: always()
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: build/ctest-results.xml
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          job_summary: true


### PR DESCRIPTION
Added test reporting to the run-tests GitHub workflow so there's a more visible indicator of the tests being run and their pass/fail state. Switch from using a CTest wrapper around the tests to just running the `game-boy-tests` target because it had cleaner output.